### PR TITLE
Blockbuster particle system additions/changes

### DIFF
--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -509,9 +509,14 @@ blockbuster.gui:
             title: Collision
 
             enabled: Enabled
-            realisticCollision: realistic Vector Collision
+            realisticCollision: the direction vector will be mirrored on collision - realistic bounce
             drag: Collision drag adds a drag (slowdown) after particle's collision with blocks in the world
             bounciness: Bounciness multiplies particle's acceleration after collision
+            randomBounciness: randomBounciness - randomize the direction vector. It doesn't affect the velocity.
+            damp: damping - reduce the velocity on impact. Valid values are between 0 and 1. 1=highest damping -> reduces velocity completely
+            randomDamp: randomDamping - randomize the damping.
+            splitParticle: split the particles into the given count on impact - speed is divided by the count
+            splitParticleSpeedThreshold: speed threshold to activate the split process
             radius: Radius of particle's hitbox
             expire: Expire on contact
 

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -509,7 +509,7 @@ blockbuster.gui:
             title: Collision
 
             enabled: Enabled
-            realisticCollision: the direction vector will be mirrored on collision - realistic bounce
+            realisticCollision: realistic collision
             drag: Collision drag adds a drag (slowdown) after particle's collision with blocks in the world
             bounciness: Bounciness multiplies particle's acceleration after collision
             randomBounciness: randomBounciness - randomize the direction vector. It doesn't affect the velocity.
@@ -519,7 +519,7 @@ blockbuster.gui:
                 randomness: randomDamping - randomize the damping.
             splitParticle:
                 title: split particle
-            	
+                
                 count: split the particles into the given count on impact - speed is divided by the count
                 speedThreshold: speed threshold to activate the split process
             radius: Radius of particle's hitbox

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -380,6 +380,9 @@ blockbuster.gui:
 
             position: Local position
             rotation: Local rotation
+            direction: Local direction
+            acceleration: Local acceleration
+            gravity: gravity
 
         initialization:
             title: Initialization expressions
@@ -506,6 +509,7 @@ blockbuster.gui:
             title: Collision
 
             enabled: Enabled
+            realisticCollision: realistic Vector Collision
             drag: Collision drag adds a drag (slowdown) after particle's collision with blocks in the world
             bounciness: Bounciness multiplies particle's acceleration after collision
             radius: Radius of particle's hitbox

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -513,10 +513,15 @@ blockbuster.gui:
             drag: Collision drag adds a drag (slowdown) after particle's collision with blocks in the world
             bounciness: Bounciness multiplies particle's acceleration after collision
             randomBounciness: randomBounciness - randomize the direction vector. It doesn't affect the velocity.
-            damp: damping - reduce the velocity on impact. Valid values are between 0 and 1. 1=highest damping -> reduces velocity completely
-            randomDamp: randomDamping - randomize the damping.
-            splitParticle: split the particles into the given count on impact - speed is divided by the count
-            splitParticleSpeedThreshold: speed threshold to activate the split process
+            damping:
+            	title: damping
+                strength: damping - reduce the velocity on impact. Valid values are between 0 and 1. 1=highest damping -> reduces velocity completely
+                randomness: randomDamping - randomize the damping.
+            splitParticle:
+            	title: split particle
+            	
+            	count: split the particles into the given count on impact - speed is divided by the count
+            	speedThreshold: speed threshold to activate the split process
             radius: Radius of particle's hitbox
             expire: Expire on contact
 

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -521,20 +521,20 @@ blockbuster.gui:
 
             enabled: Enabled
             realisticCollision: Realistic collision
-            preserveEnergy: Preserve Energy
+            preserveEnergy: Preserve energy
             entityCollision: Collision with entities
-            momentum: Momentum for entity Collision
+            momentum: Momentum for entity collision
             drag: Collision drag adds a drag (slowdown) after particle's collision with blocks in the world
             bounciness: Bounciness multiplies particle's acceleration after collision
-            randomBounciness: randomBounciness - randomize the direction vector. It doesn't affect the velocity.
+            randomDirection: Random Direction - randomize the direction vector. It doesn't affect the velocity.
             damping:
-                title: damping
-                strength: damping - reduce the velocity on impact. Valid values are between 0 and 1. 1=highest damping -> reduces velocity completely
-                randomness: randomDamping - randomize the damping.
+                title: Damping
+                strength: Damping - reduce the velocity on impact. Valid values are between 0 and 1. 1=highest damping -> reduces velocity completely
+                randomness: Randomize the damping
             splitParticle:
-                title: split particle
+                title: Split particle
                 
-                count: split the particles into the given count on impact - speed is divided by the count
+                count: Split the particle on impact into the given count - speed is divided by the count
                 speedThreshold: speed threshold to activate the split process
             radius: Radius of particle's hitbox
             expire: Expire on contact

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -514,14 +514,14 @@ blockbuster.gui:
             bounciness: Bounciness multiplies particle's acceleration after collision
             randomBounciness: randomBounciness - randomize the direction vector. It doesn't affect the velocity.
             damping:
-            	title: damping
+                title: damping
                 strength: damping - reduce the velocity on impact. Valid values are between 0 and 1. 1=highest damping -> reduces velocity completely
                 randomness: randomDamping - randomize the damping.
             splitParticle:
-            	title: split particle
+                title: split particle
             	
-            	count: split the particles into the given count on impact - speed is divided by the count
-            	speedThreshold: speed threshold to activate the split process
+                count: split the particles into the given count on impact - speed is divided by the count
+                speedThreshold: speed threshold to activate the split process
             radius: Radius of particle's hitbox
             expire: Expire on contact
 

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -525,6 +525,9 @@ blockbuster.gui:
             radius: Radius of particle's hitbox
             expire: Expire on contact
             expirationDelay: Delay the expiration. Measured in ticks - 20 = 1 second
+            
+            appearance:
+                title: Texture on Colllision
 
     record_morph:
         random_skip: Random Skip

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -473,7 +473,18 @@ blockbuster.gui:
 
             regular: Regular
             animated: Animated
-
+            
+            cameraFacing:
+                label: Facing mode
+                
+                direction_x: Direction X
+                direction_y: Direction Y
+                direction_z: Direction Z
+                lookat_xyz: Look at XYZ
+                lookat_y: Look at Y
+                rotate_xyz: Rotate XYZ
+                rotate_y: Rotate Y
+            
             size: Billboard size
             width: Width
             height: Height
@@ -509,7 +520,10 @@ blockbuster.gui:
             title: Collision
 
             enabled: Enabled
-            realisticCollision: realistic collision
+            realisticCollision: Realistic collision
+            preserveEnergy: Preserve Energy
+            entityCollision: Collision with entities
+            momentum: Momentum for entity Collision
             drag: Collision drag adds a drag (slowdown) after particle's collision with blocks in the world
             bounciness: Bounciness multiplies particle's acceleration after collision
             randomBounciness: randomBounciness - randomize the direction vector. It doesn't affect the velocity.
@@ -527,7 +541,9 @@ blockbuster.gui:
             expirationDelay: Delay the expiration. Measured in ticks - 20 = 1 second
             
             appearance:
-                title: Texture on Colllision
+                title: Texture on colllision
+            lighting:
+                title: Lighting on collision
 
     record_morph:
         random_skip: Random Skip

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -524,6 +524,7 @@ blockbuster.gui:
                 speedThreshold: speed threshold to activate the split process
             radius: Radius of particle's hitbox
             expire: Expire on contact
+            expirationDelay: Delay the expiration. Measured in ticks - 20 = 1 second
 
     record_morph:
         random_skip: Random Skip

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/GuiSnowstorm.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/GuiSnowstorm.java
@@ -4,6 +4,7 @@ import jdk.nashorn.internal.ir.Block;
 import mchorse.blockbuster.Blockbuster;
 import mchorse.blockbuster.client.gui.dashboard.GuiBlockbusterPanel;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormAppearanceSection;
+import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormCollisionAppearanceSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormCollisionSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormExpirationSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormGeneralSection;
@@ -126,7 +127,8 @@ public class GuiSnowstorm extends GuiBlockbusterPanel
 		this.addSection(new GuiSnowstormAppearanceSection(mc, this));
 		this.addSection(new GuiSnowstormLightingSection(mc, this));
 		this.addSection(new GuiSnowstormCollisionSection(mc, this));
-
+		this.addSection(new GuiSnowstormCollisionAppearanceSection(mc, this));
+		
 		this.keys()
 			.register(IKey.lang("blockbuster.gui.snowstorm.keys.save"), Keyboard.KEY_S, () -> this.save.clickItself(GuiBase.getCurrent()))
 			.held(Keyboard.KEY_LCONTROL).category(IKey.lang("blockbuster.gui.snowstorm.keys.category"));

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/GuiSnowstorm.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/GuiSnowstorm.java
@@ -5,6 +5,7 @@ import mchorse.blockbuster.Blockbuster;
 import mchorse.blockbuster.client.gui.dashboard.GuiBlockbusterPanel;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormAppearanceSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormCollisionAppearanceSection;
+import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormCollisionLightingSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormCollisionSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormExpirationSection;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections.GuiSnowstormGeneralSection;
@@ -128,6 +129,7 @@ public class GuiSnowstorm extends GuiBlockbusterPanel
 		this.addSection(new GuiSnowstormLightingSection(mc, this));
 		this.addSection(new GuiSnowstormCollisionSection(mc, this));
 		this.addSection(new GuiSnowstormCollisionAppearanceSection(mc, this));
+		this.addSection(new GuiSnowstormCollisionLightingSection(mc, this));
 		
 		this.keys()
 			.register(IKey.lang("blockbuster.gui.snowstorm.keys.save"), Keyboard.KEY_S, () -> this.save.clickItself(GuiBase.getCurrent()))

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormAppearanceSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormAppearanceSection.java
@@ -3,6 +3,7 @@ package mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections;
 import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.GuiSnowstorm;
 import mchorse.blockbuster.client.particles.BedrockScheme;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceBillboard;
+import mchorse.blockbuster.client.particles.components.appearance.CameraFacing;
 import mchorse.mclib.client.gui.framework.elements.GuiElement;
 import mchorse.mclib.client.gui.framework.elements.buttons.GuiCirculateElement;
 import mchorse.mclib.client.gui.framework.elements.buttons.GuiToggleElement;
@@ -17,7 +18,9 @@ public class GuiSnowstormAppearanceSection extends GuiSnowstormComponentSection<
 {
 	public GuiCirculateElement mode;
 	public GuiLabel modeLabel;
-
+	
+	public GuiCirculateElement facingMode;
+	public GuiLabel facingModeLabel;
 	public GuiTextElement sizeW;
 	public GuiTextElement sizeH;
 	public GuiTextElement uvX;
@@ -33,6 +36,9 @@ public class GuiSnowstormAppearanceSection extends GuiSnowstormComponentSection<
 	public GuiToggleElement stretch;
 	public GuiToggleElement loop;
 
+	public CameraFacing[] facingModes = {CameraFacing.DIRECTION_X, CameraFacing.DIRECTION_Y, CameraFacing.DIRECTION_Z, CameraFacing.LOOKAT_XYZ,
+										 CameraFacing.LOOKAT_Y, CameraFacing.ROTATE_XYZ, CameraFacing.ROTATE_Y};
+	
 	public GuiSnowstormAppearanceSection(Minecraft mc, GuiSnowstorm parent)
 	{
 		super(mc, parent);
@@ -46,7 +52,21 @@ public class GuiSnowstormAppearanceSection extends GuiSnowstormComponentSection<
 		this.mode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.regular"));
 		this.mode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.animated"));
 		this.modeLabel = Elements.label(IKey.lang("blockbuster.gui.snowstorm.mode"), 20).anchor(0, 0.5F);
-
+		
+		this.facingMode = new GuiCirculateElement(mc, (b) ->
+		{
+			this.component.facing = facingModes[this.facingMode.getValue()];
+			this.parent.dirty();
+		});
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.direction_x"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.direction_y"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.direction_z"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.lookat_xyz"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.lookat_y"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.rotate_xyz"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.rotate_y"));
+		this.facingModeLabel = Elements.label(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.label"), 20).anchor(0, 0.5F);
+		
 		this.sizeW = new GuiTextElement(mc, 10000, (str) -> this.component.sizeW = this.parse(str, this.sizeW, this.component.sizeW));
 		this.sizeW.tooltip(IKey.lang("blockbuster.gui.snowstorm.appearance.width"));
 		this.sizeH = new GuiTextElement(mc, 10000, (str) -> this.component.sizeH = this.parse(str, this.sizeH, this.component.sizeH));
@@ -103,6 +123,7 @@ public class GuiSnowstormAppearanceSection extends GuiSnowstormComponentSection<
 		this.flipbook.add(Elements.row(mc, 5, 0, 20, this.stretch, this.loop));
 
 		this.fields.add(Elements.row(mc, 5, 0, 20, this.modeLabel, this.mode));
+		this.fields.add(Elements.row(mc, 5, 0, 20, this.facingModeLabel, this.facingMode));
 		this.fields.add(Elements.label(IKey.lang("blockbuster.gui.snowstorm.appearance.size"), 20).anchor(0, 1F));
 		this.fields.add(this.sizeW, this.sizeH);
 		this.fields.add(Elements.label(IKey.lang("blockbuster.gui.snowstorm.appearance.mapping"), 20).anchor(0, 1F));
@@ -139,6 +160,16 @@ public class GuiSnowstormAppearanceSection extends GuiSnowstormComponentSection<
 		super.fillData();
 
 		this.mode.setValue(this.component.flipbook ? 1 : 0);
+		int facingModeI = -1;
+		for(int i = 0; i<this.facingModes.length; i++)
+		{
+			if(this.facingModes[i]==this.component.facing)
+			{
+				facingModeI = i;
+				break;
+			}
+		}
+		this.facingMode.setValue(facingModeI);
 		this.set(this.sizeW, this.component.sizeW);
 		this.set(this.sizeH, this.component.sizeH);
 		this.set(this.uvX, this.component.uvX);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
@@ -5,6 +5,9 @@ import mchorse.blockbuster.client.particles.BedrockMaterial;
 import mchorse.blockbuster.client.particles.BedrockScheme;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceBillboard;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionTinting;
+import mchorse.blockbuster.client.particles.molang.MolangParser;
+import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
 import mchorse.mclib.client.gui.framework.elements.GuiElement;
 import mchorse.mclib.client.gui.framework.elements.buttons.GuiButtonElement;
 import mchorse.mclib.client.gui.framework.elements.buttons.GuiCirculateElement;
@@ -24,6 +27,7 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	//inheriting this throughout the structure would make things less copy and paste
 	public static final String GUIPATH = "blockbuster.gui.snowstorm.appearance";
 	
+	public GuiToggleElement enabled;
 	public GuiButtonElement pick;
 	public GuiCirculateElement material;
 	public GuiTexturePicker texture;
@@ -50,6 +54,8 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	{
 		super(mc, parent);
 
+		this.enabled = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.enabled"), (b) -> this.parent.dirty());
+		
 		this.pick = new GuiButtonElement(mc, IKey.lang("blockbuster.gui.snowstorm.general.pick"), (b) ->
 		{
 			GuiElement container = this.getParentContainer();
@@ -147,6 +153,7 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 		this.flipbook.add(Elements.row(mc, 5, 0, 20, this.fps, this.max));
 		this.flipbook.add(Elements.row(mc, 5, 0, 20, this.stretch, this.loop));
 
+		this.fields.add(this.enabled);
 		this.fields.add(Elements.row(mc, 5, 0, 20, this.pick, this.material));
 		this.fields.add(Elements.row(mc, 5, 0, 20, this.modeLabel, this.mode));
 		this.fields.add(Elements.label(IKey.lang(GUIPATH+".size"), 20).anchor(0, 1F));
@@ -181,7 +188,13 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	{
 		super.setScheme(scheme);
 
-		this.material.setValue(scheme.material.ordinal());
+		this.material.setValue(this.component.material.ordinal());
+	}
+	
+	@Override
+	public void beforeSave(BedrockScheme scheme)
+	{
+		this.component.enabled = this.enabled.isToggled() ? MolangParser.ONE : MolangParser.ZERO;
 	}
 
 	@Override
@@ -206,6 +219,7 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	{
 		super.fillData();
 
+		//this.enabled.toggled(MolangExpression.isOne(this.scheme.get(BedrockComponentCollisionAppearance.class).enabled));
 		this.mode.setValue(this.component.flipbook ? 1 : 0);
 		this.set(this.sizeW, this.component.sizeW);
 		this.set(this.sizeH, this.component.sizeH);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
@@ -6,6 +6,7 @@ import mchorse.blockbuster.client.particles.BedrockScheme;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceBillboard;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionTinting;
+import mchorse.blockbuster.client.particles.components.appearance.CameraFacing;
 import mchorse.blockbuster.client.particles.molang.MolangParser;
 import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
 import mchorse.mclib.client.gui.framework.elements.GuiElement;
@@ -35,6 +36,8 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	public GuiCirculateElement mode;
 	public GuiLabel modeLabel;
 
+	public GuiCirculateElement facingMode;
+	public GuiLabel facingModeLabel;
 	public GuiTextElement sizeW;
 	public GuiTextElement sizeH;
 	public GuiTextElement uvX;
@@ -49,6 +52,9 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	public GuiTextElement max;
 	public GuiToggleElement stretch;
 	public GuiToggleElement loop;
+	
+	public CameraFacing[] facingModes = {CameraFacing.DIRECTION_X, CameraFacing.DIRECTION_Y, CameraFacing.DIRECTION_Z, CameraFacing.LOOKAT_XYZ,
+			 CameraFacing.LOOKAT_Y, CameraFacing.ROTATE_XYZ, CameraFacing.ROTATE_Y};
 	
 	public GuiSnowstormCollisionAppearanceSection(Minecraft mc, GuiSnowstorm parent)
 	{
@@ -98,6 +104,20 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 		this.mode.addLabel(IKey.lang(GUIPATH+".animated"));
 		this.modeLabel = Elements.label(IKey.lang("blockbuster.gui.snowstorm.mode"), 20).anchor(0, 0.5F);
 
+		this.facingMode = new GuiCirculateElement(mc, (b) ->
+		{
+			this.component.facing = facingModes[this.facingMode.getValue()];
+			this.parent.dirty();
+		});
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.direction_x"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.direction_y"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.direction_z"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.lookat_xyz"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.lookat_y"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.rotate_xyz"));
+		this.facingMode.addLabel(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.rotate_y"));
+		this.facingModeLabel = Elements.label(IKey.lang("blockbuster.gui.snowstorm.appearance.cameraFacing.label"), 20).anchor(0, 0.5F);
+		
 		this.sizeW = new GuiTextElement(mc, 10000, (str) -> this.component.sizeW = this.parse(str, this.sizeW, this.component.sizeW));
 		this.sizeW.tooltip(IKey.lang(GUIPATH+".width"));
 		this.sizeH = new GuiTextElement(mc, 10000, (str) -> this.component.sizeH = this.parse(str, this.sizeH, this.component.sizeH));
@@ -156,6 +176,7 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 		this.fields.add(this.enabled);
 		this.fields.add(Elements.row(mc, 5, 0, 20, this.pick, this.material));
 		this.fields.add(Elements.row(mc, 5, 0, 20, this.modeLabel, this.mode));
+		this.fields.add(Elements.row(mc, 5, 0, 20, this.facingModeLabel, this.facingMode));
 		this.fields.add(Elements.label(IKey.lang(GUIPATH+".size"), 20).anchor(0, 1F));
 		this.fields.add(this.sizeW, this.sizeH);
 		this.fields.add(Elements.label(IKey.lang(GUIPATH+".mapping"), 20).anchor(0, 1F));
@@ -221,6 +242,16 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 
 		this.enabled.toggled(MolangExpression.isOne(component.enabled));
 		this.mode.setValue(this.component.flipbook ? 1 : 0);
+		int facingModeI = -1;
+		for(int i = 0; i<this.facingModes.length; i++)
+		{
+			if(this.facingModes[i]==this.component.facing)
+			{
+				facingModeI = i;
+				break;
+			}
+		}
+		this.facingMode.setValue(facingModeI);
 		this.set(this.sizeW, this.component.sizeW);
 		this.set(this.sizeH, this.component.sizeH);
 		this.set(this.uvX, this.component.uvX);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
@@ -219,7 +219,7 @@ public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponen
 	{
 		super.fillData();
 
-		//this.enabled.toggled(MolangExpression.isOne(this.scheme.get(BedrockComponentCollisionAppearance.class).enabled));
+		this.enabled.toggled(MolangExpression.isOne(component.enabled));
 		this.mode.setValue(this.component.flipbook ? 1 : 0);
 		this.set(this.sizeW, this.component.sizeW);
 		this.set(this.sizeH, this.component.sizeH);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionAppearanceSection.java
@@ -1,0 +1,227 @@
+package mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections;
+
+import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.GuiSnowstorm;
+import mchorse.blockbuster.client.particles.BedrockMaterial;
+import mchorse.blockbuster.client.particles.BedrockScheme;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceBillboard;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
+import mchorse.mclib.client.gui.framework.elements.GuiElement;
+import mchorse.mclib.client.gui.framework.elements.buttons.GuiButtonElement;
+import mchorse.mclib.client.gui.framework.elements.buttons.GuiCirculateElement;
+import mchorse.mclib.client.gui.framework.elements.buttons.GuiToggleElement;
+import mchorse.mclib.client.gui.framework.elements.input.GuiTextElement;
+import mchorse.mclib.client.gui.framework.elements.input.GuiTexturePicker;
+import mchorse.mclib.client.gui.framework.elements.input.GuiTrackpadElement;
+import mchorse.mclib.client.gui.framework.elements.utils.GuiLabel;
+import mchorse.mclib.client.gui.utils.Elements;
+import mchorse.mclib.client.gui.utils.keys.IKey;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.ResourceLocation;
+import org.lwjgl.opengl.GL11;
+
+public class GuiSnowstormCollisionAppearanceSection extends GuiSnowstormComponentSection<BedrockComponentCollisionAppearance>
+{
+	//inheriting this throughout the structure would make things less copy and paste
+	public static final String GUIPATH = "blockbuster.gui.snowstorm.appearance";
+	
+	public GuiButtonElement pick;
+	public GuiCirculateElement material;
+	public GuiTexturePicker texture;
+	
+	public GuiCirculateElement mode;
+	public GuiLabel modeLabel;
+
+	public GuiTextElement sizeW;
+	public GuiTextElement sizeH;
+	public GuiTextElement uvX;
+	public GuiTextElement uvY;
+	public GuiTextElement uvW;
+	public GuiTextElement uvH;
+
+	public GuiElement flipbook;
+	public GuiTrackpadElement stepX;
+	public GuiTrackpadElement stepY;
+	public GuiTrackpadElement fps;
+	public GuiTextElement max;
+	public GuiToggleElement stretch;
+	public GuiToggleElement loop;
+	
+	public GuiSnowstormCollisionAppearanceSection(Minecraft mc, GuiSnowstorm parent)
+	{
+		super(mc, parent);
+
+		this.pick = new GuiButtonElement(mc, IKey.lang("blockbuster.gui.snowstorm.general.pick"), (b) ->
+		{
+			GuiElement container = this.getParentContainer();
+
+			this.texture.fill(this.component.texture);
+			this.texture.flex().relative(container).wh(1F, 1F);
+			this.texture.resize();
+			container.add(this.texture);
+		});
+
+		this.material = new GuiCirculateElement(mc, (b) ->
+		{
+			this.component.material = BedrockMaterial.values()[this.material.getValue()];
+			this.parent.dirty();
+		});
+		this.material.addLabel(IKey.lang("blockbuster.gui.snowstorm.general.particles_opaque"));
+		this.material.addLabel(IKey.lang("blockbuster.gui.snowstorm.general.particles_alpha"));
+		this.material.addLabel(IKey.lang("blockbuster.gui.snowstorm.general.particles_blend"));
+
+		this.texture = new GuiTexturePicker(mc, (rl) ->
+		{
+			if (rl == null)
+			{
+				rl = BedrockScheme.DEFAULT_TEXTURE;
+			}
+
+			this.setTextureSize(rl);
+			this.component.texture = rl;
+			this.parent.dirty();
+		});
+
+		
+		this.mode = new GuiCirculateElement(mc, (b) ->
+		{
+			this.component.flipbook = this.mode.getValue() == 1;
+			this.updateElements();
+			this.parent.dirty();
+		});
+		this.mode.addLabel(IKey.lang(GUIPATH+".regular"));
+		this.mode.addLabel(IKey.lang(GUIPATH+".animated"));
+		this.modeLabel = Elements.label(IKey.lang("blockbuster.gui.snowstorm.mode"), 20).anchor(0, 0.5F);
+
+		this.sizeW = new GuiTextElement(mc, 10000, (str) -> this.component.sizeW = this.parse(str, this.sizeW, this.component.sizeW));
+		this.sizeW.tooltip(IKey.lang(GUIPATH+".width"));
+		this.sizeH = new GuiTextElement(mc, 10000, (str) -> this.component.sizeH = this.parse(str, this.sizeH, this.component.sizeH));
+		this.sizeH.tooltip(IKey.lang(GUIPATH+".height"));
+
+		this.uvX = new GuiTextElement(mc, 10000, (str) -> this.component.uvX = this.parse(str, this.uvX, this.component.uvX));
+		this.uvX.tooltip(IKey.lang(GUIPATH+".uv_x"));
+		this.uvY = new GuiTextElement(mc, 10000, (str) -> this.component.uvY = this.parse(str, this.uvY, this.component.uvY));
+		this.uvY.tooltip(IKey.lang(GUIPATH+".uv_y"));
+		this.uvW = new GuiTextElement(mc, 10000, (str) -> this.component.uvW = this.parse(str, this.uvW, this.component.uvW));
+		this.uvW.tooltip(IKey.lang(GUIPATH+".uv_w"));
+		this.uvH = new GuiTextElement(mc, 10000, (str) -> this.component.uvH = this.parse(str, this.uvH, this.component.uvH));
+		this.uvH.tooltip(IKey.lang(GUIPATH+".uv_h"));
+
+		this.stepX = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.stepX = value.floatValue();
+			this.parent.dirty();
+		});
+		this.stepX.tooltip(IKey.lang(GUIPATH+".step_x"));
+		this.stepY = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.stepY = value.floatValue();
+			this.parent.dirty();
+		});
+		this.stepY.tooltip(IKey.lang(GUIPATH+".step_y"));
+		this.fps = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.fps = value.floatValue();
+			this.parent.dirty();
+		});
+		this.fps.tooltip(IKey.lang(GUIPATH+".fps"));
+		this.max = new GuiTextElement(mc, 10000, (str) -> this.component.maxFrame = this.parse(str, this.max, this.component.maxFrame));
+		this.max.tooltip(IKey.lang(GUIPATH+".max"));
+
+		this.stretch = new GuiToggleElement(mc, IKey.lang(GUIPATH+".stretch"), (b) ->
+		{
+			this.component.stretchFPS = b.isToggled();
+			this.parent.dirty();
+		});
+		this.stretch.tooltip(IKey.lang(GUIPATH+".stretch_tooltip"));
+		this.loop = new GuiToggleElement(mc, IKey.lang(GUIPATH+".loop"), (b) ->
+		{
+			this.component.loop = b.isToggled();
+			this.parent.dirty();
+		});
+		this.loop.tooltip(IKey.lang(GUIPATH+".loop_tooltip"));
+
+		this.flipbook = new GuiElement(mc);
+		this.flipbook.flex().column(5).vertical().stretch();
+		this.flipbook.add(Elements.label(IKey.lang(GUIPATH+".animated"), 20).anchor(0, 1F));
+		this.flipbook.add(Elements.row(mc, 5, 0, 20, this.stepX, this.stepY));
+		this.flipbook.add(Elements.row(mc, 5, 0, 20, this.fps, this.max));
+		this.flipbook.add(Elements.row(mc, 5, 0, 20, this.stretch, this.loop));
+
+		this.fields.add(Elements.row(mc, 5, 0, 20, this.pick, this.material));
+		this.fields.add(Elements.row(mc, 5, 0, 20, this.modeLabel, this.mode));
+		this.fields.add(Elements.label(IKey.lang(GUIPATH+".size"), 20).anchor(0, 1F));
+		this.fields.add(this.sizeW, this.sizeH);
+		this.fields.add(Elements.label(IKey.lang(GUIPATH+".mapping"), 20).anchor(0, 1F));
+		this.fields.add(this.uvX, this.uvY, this.uvW, this.uvH);
+	}
+
+	private void setTextureSize(ResourceLocation rl)
+	{
+		BedrockComponentCollisionAppearance component = this.scheme.get(BedrockComponentCollisionAppearance.class);
+
+		if (component == null)
+		{
+			return;
+		}
+
+		this.mc.renderEngine.bindTexture(rl);
+
+		component.textureWidth = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_WIDTH);
+		component.textureHeight = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_HEIGHT);
+	}
+
+	@Override
+	public String getTitle()
+	{
+		return "blockbuster.gui.snowstorm.collision.appearance.title";
+	}
+
+	@Override
+	public void setScheme(BedrockScheme scheme)
+	{
+		super.setScheme(scheme);
+
+		this.material.setValue(scheme.material.ordinal());
+	}
+
+	@Override
+	protected BedrockComponentCollisionAppearance getComponent(BedrockScheme scheme) {
+		return scheme.getOrCreate(BedrockComponentCollisionAppearance.class);
+	}
+	
+	private void updateElements()
+	{
+		this.flipbook.removeFromParent();
+
+		if (this.component.flipbook)
+		{
+			this.fields.add(this.flipbook);
+		}
+
+		this.resizeParent();
+	}
+	
+	@Override
+	protected void fillData()
+	{
+		super.fillData();
+
+		this.mode.setValue(this.component.flipbook ? 1 : 0);
+		this.set(this.sizeW, this.component.sizeW);
+		this.set(this.sizeH, this.component.sizeH);
+		this.set(this.uvX, this.component.uvX);
+		this.set(this.uvY, this.component.uvY);
+		this.set(this.uvW, this.component.uvW);
+		this.set(this.uvH, this.component.uvH);
+
+		this.stepX.setValue(this.component.stepX);
+		this.stepY.setValue(this.component.stepY);
+		this.fps.setValue(this.component.fps);
+		this.set(this.max, this.component.maxFrame);
+
+		this.stretch.toggled(this.component.stretchFPS);
+		this.loop.toggled(this.component.loop);
+
+		this.updateElements();
+	}
+}

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionLightingSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionLightingSection.java
@@ -166,7 +166,8 @@ public class GuiSnowstormCollisionLightingSection extends GuiSnowstormSection
 		this.component = scheme.getOrCreate(BedrockComponentCollisionTinting.class);
 		this.appearanceComponent = scheme.getOrCreate(BedrockComponentCollisionAppearance.class);
 		this.lighting.toggled(!appearanceComponent.lit);
-
+		this.enabled.toggled(MolangExpression.isOne(component.enabled));
+		
 		if (this.component.color instanceof Tint.Solid)
 		{
 			Tint.Solid solid = this.getSolid();

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionLightingSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionLightingSection.java
@@ -165,8 +165,8 @@ public class GuiSnowstormCollisionLightingSection extends GuiSnowstormSection
 
 		this.component = scheme.getOrCreate(BedrockComponentCollisionTinting.class);
 		this.appearanceComponent = scheme.getOrCreate(BedrockComponentCollisionAppearance.class);
-		this.lighting.toggled(!appearanceComponent.lit);
-		this.enabled.toggled(MolangExpression.isOne(component.enabled));
+		this.lighting.toggled(!this.appearanceComponent.lit);
+		this.enabled.toggled(MolangExpression.isOne(this.component.enabled));
 		
 		if (this.component.color instanceof Tint.Solid)
 		{

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionLightingSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionLightingSection.java
@@ -1,0 +1,216 @@
+package mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.sections;
+
+import mchorse.blockbuster.client.gui.dashboard.panels.snowstorm.GuiSnowstorm;
+import mchorse.blockbuster.client.particles.BedrockScheme;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceLighting;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceTinting;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionTinting;
+import mchorse.blockbuster.client.particles.components.appearance.Tint;
+import mchorse.blockbuster.client.particles.molang.MolangParser;
+import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
+import mchorse.blockbuster.client.particles.molang.expressions.MolangValue;
+import mchorse.mclib.client.gui.framework.elements.GuiElement;
+import mchorse.mclib.client.gui.framework.elements.buttons.GuiCirculateElement;
+import mchorse.mclib.client.gui.framework.elements.buttons.GuiToggleElement;
+import mchorse.mclib.client.gui.framework.elements.input.GuiColorElement;
+import mchorse.mclib.client.gui.framework.elements.input.GuiTextElement;
+import mchorse.mclib.client.gui.framework.elements.utils.GuiLabel;
+import mchorse.mclib.client.gui.utils.Elements;
+import mchorse.mclib.client.gui.utils.keys.IKey;
+import mchorse.mclib.math.Constant;
+import mchorse.mclib.utils.Color;
+import net.minecraft.client.Minecraft;
+
+public class GuiSnowstormCollisionLightingSection extends GuiSnowstormSection
+{
+	public GuiToggleElement enabled;
+	public GuiCirculateElement mode;
+	public GuiColorElement color;
+	public GuiTextElement r;
+	public GuiTextElement g;
+	public GuiTextElement b;
+	public GuiTextElement a;
+	public GuiToggleElement lighting;
+
+	public GuiElement first;
+	public GuiElement second;
+
+	private BedrockComponentCollisionTinting component;
+	private BedrockComponentCollisionAppearance appearanceComponent;
+
+	public GuiSnowstormCollisionLightingSection(Minecraft mc, GuiSnowstorm parent)
+	{
+		super(mc, parent);
+		this.enabled = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.enabled"), (b) -> this.parent.dirty());
+		this.mode = new GuiCirculateElement(mc, (b) ->
+		{
+			this.fillData();
+			this.parent.dirty();
+		});
+		this.mode.addLabel(IKey.lang("blockbuster.gui.snowstorm.lighting.solid"));
+		this.mode.addLabel(IKey.lang("blockbuster.gui.snowstorm.lighting.expression"));
+
+		this.color = new GuiColorElement(mc, (color) ->
+		{
+			Tint.Solid solid = this.getSolid();
+			Color original = this.color.picker.color;
+
+			solid.r = this.set(solid.r, original.r);
+			solid.g = this.set(solid.g, original.g);
+			solid.b = this.set(solid.b, original.b);
+			solid.a = this.set(solid.a, original.a);
+			this.parent.dirty();
+		});
+		this.color.picker.editAlpha();
+
+		this.r = new GuiTextElement(mc, 10000, (str) ->
+		{
+			Tint.Solid solid = this.getSolid();
+
+			solid.r = this.parse(str, this.r, solid.r);
+		});
+		this.r.tooltip(IKey.lang("blockbuster.gui.snowstorm.lighting.red"));
+
+		this.g = new GuiTextElement(mc, 10000, (str) ->
+		{
+			Tint.Solid solid = this.getSolid();
+
+			solid.g = this.parse(str, this.r, solid.g);
+		});
+		this.g.tooltip(IKey.lang("blockbuster.gui.snowstorm.lighting.green"));
+
+		this.b = new GuiTextElement(mc, 10000, (str) ->
+		{
+			Tint.Solid solid = this.getSolid();
+
+			solid.b = this.parse(str, this.r, solid.b);
+		});
+		this.b.tooltip(IKey.lang("blockbuster.gui.snowstorm.lighting.blue"));
+
+		this.a = new GuiTextElement(mc, 10000, (str) ->
+		{
+			Tint.Solid solid = this.getSolid();
+
+			solid.a = this.parse(str, this.r, solid.a);
+		});
+		this.a.tooltip(IKey.lang("blockbuster.gui.snowstorm.lighting.alpha"));
+
+		this.lighting = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.lighting.lighting"), (b) -> 
+		{
+			this.appearanceComponent.lit = !b.isToggled();
+			this.parent.dirty();
+		});
+
+		GuiLabel label = Elements.label(IKey.lang("blockbuster.gui.snowstorm.mode"), 20).anchor(0, 0.5F);
+
+		this.first = Elements.row(mc, 5, 0, 20, this.r, this.g);
+		this.second = Elements.row(mc, 5, 0, 20, this.b, this.a);
+		this.fields.add(this.enabled);
+		this.fields.add(this.lighting);
+		this.fields.add(Elements.row(mc, 5, 0, 20, label, this.mode));
+	}
+
+	private MolangExpression set(MolangExpression expression, float value)
+	{
+		if (expression == MolangParser.ZERO || expression == MolangParser.ONE)
+		{
+			return new MolangValue(null, new Constant(value));
+		}
+
+		if (!(expression instanceof MolangValue))
+		{
+			expression = new MolangValue(null, new Constant(0));
+		}
+
+		if (expression instanceof MolangValue)
+		{
+			MolangValue v = (MolangValue) expression;
+
+			if (!(v.value instanceof Constant))
+			{
+				v.value = new Constant(0);
+			}
+
+			if (v.value instanceof Constant)
+			{
+				((Constant) v.value).set(value);
+			}
+		}
+
+		return expression;
+	}
+
+	@Override
+	public String getTitle()
+	{
+		return "blockbuster.gui.snowstorm.collision.lighting.title";
+	}
+
+	private Tint.Solid getSolid()
+	{
+		return (Tint.Solid) this.component.color;
+	}
+
+	@Override
+	public void beforeSave(BedrockScheme scheme)
+	{
+		this.component.enabled = this.enabled.isToggled() ? MolangParser.ONE : MolangParser.ZERO;
+	}
+
+	@Override
+	public void setScheme(BedrockScheme scheme)
+	{
+		super.setScheme(scheme);
+
+		this.component = scheme.getOrCreate(BedrockComponentCollisionTinting.class);
+		this.appearanceComponent = scheme.getOrCreate(BedrockComponentCollisionAppearance.class);
+		this.lighting.toggled(!appearanceComponent.lit);
+
+		if (this.component.color instanceof Tint.Solid)
+		{
+			Tint.Solid solid = this.getSolid();
+
+			if (solid.isConstant())
+			{
+				this.mode.setValue(0);
+			}
+			else
+			{
+				this.mode.setValue(1);
+			}
+
+			this.fillData();
+		}
+	}
+
+	public void fillData()
+	{
+		Tint.Solid solid = this.getSolid();
+
+		//this.enabled.toggled(MolangExpression.isOne(this.component.enabled));
+		this.color.removeFromParent();
+		this.color.picker.removeFromParent();
+		this.first.removeFromParent();
+		this.second.removeFromParent();
+
+		if (this.mode.getValue() == 0)
+		{
+			this.color.picker.color.set((float) solid.r.get(), (float) solid.g.get(), (float) solid.b.get(), (float) solid.a.get());
+
+			this.fields.add(this.color);
+		}
+		else
+		{
+			this.set(this.r, solid.r);
+			this.set(this.g, solid.g);
+			this.set(this.b, solid.b);
+			this.set(this.a, solid.a);
+
+			this.fields.add(this.first);
+			this.fields.add(this.second);
+		}
+
+		this.resizeParent();
+	}
+}

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -96,6 +96,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 		this.randomDamp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.damping.randomness"));
+		this.randomDamp.limit(0, 1);
 		
 		this.splitParticleSpeedThreshold = new GuiTrackpadElement(mc, (value) ->
 		{
@@ -110,6 +111,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 		this.splitParticle.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle.count"));
+		this.splitParticle.limit(0, 99);
 		
 		this.radius = new GuiTrackpadElement(mc, (value) ->
 		{

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -12,6 +12,7 @@ import net.minecraft.client.Minecraft;
 public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<BedrockComponentMotionCollision>
 {
 	public GuiToggleElement enabled;
+	public GuiToggleElement realisticCollision;
 	public GuiTrackpadElement drag;
 	public GuiTrackpadElement bounciness;
 	public GuiTrackpadElement radius;
@@ -24,6 +25,11 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		super(mc, parent);
 
 		this.enabled = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.enabled"), (b) -> this.parent.dirty());
+		this.realisticCollision = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.realisticCollision"), (b) ->
+		{
+			this.component.realisticCollision = b.isToggled();
+			this.parent.dirty();
+		});
 		this.drag = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.collissionDrag = value.floatValue();
@@ -48,7 +54,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.enabled, this.drag, this.bounciness, this.radius, this.expire);
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.radius, this.expire);
 	}
 
 	@Override
@@ -75,6 +81,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	protected void fillData()
 	{
 		this.enabled.toggled(this.wasPresent);
+		this.realisticCollision.toggled(this.component.realisticCollision);
 		this.drag.setValue(this.component.collissionDrag);
 		this.bounciness.setValue(this.component.bounciness);
 		this.radius.setValue(this.component.radius);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -7,6 +7,7 @@ import mchorse.blockbuster.client.particles.molang.MolangParser;
 import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
 import mchorse.mclib.client.gui.framework.elements.GuiElement;
 import mchorse.mclib.client.gui.framework.elements.buttons.GuiToggleElement;
+import mchorse.mclib.client.gui.framework.elements.input.GuiTextElement;
 import mchorse.mclib.client.gui.framework.elements.input.GuiTrackpadElement;
 import mchorse.mclib.client.gui.utils.keys.IKey;
 import mchorse.mclib.client.gui.utils.Elements;
@@ -28,7 +29,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	public GuiTrackpadElement splitParticleSpeedThreshold;
 	public GuiTrackpadElement radius;
 	public GuiToggleElement expire;
-	public GuiTrackpadElement expirationDelay;
+	public GuiTextElement expirationDelay;
 	
 	public GuiElement controlToggleElements;
 	public GuiElement randomBouncinessRow;
@@ -126,9 +127,9 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 		
-		this.expirationDelay = new GuiTrackpadElement(mc, (value) ->
+		this.expirationDelay = new GuiTextElement(mc, (value) ->
 		{
-			this.component.expirationDelay = value.intValue();
+			this.component.expirationDelay = this.parse(value, this.expirationDelay, this.component.expirationDelay);
 			this.parent.dirty();
 		});
 		this.expirationDelay.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.expirationDelay"));
@@ -188,7 +189,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.splitParticleSpeedThreshold.setValue(this.component.splitParticleSpeedThreshold);
 		this.radius.setValue(this.component.radius);
 		this.expire.toggled(this.component.expireOnImpact);
-		this.expirationDelay.setValue(this.component.expirationDelay);
+		this.set(this.expirationDelay, this.component.expirationDelay);
 		
 		if(this.entityCollision.isToggled()) {
 			this.controlToggleElements.add(momentum);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -115,8 +115,8 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.drag.setValue(this.component.collissionDrag);
 		this.bounciness.setValue(this.component.bounciness);
 		this.randomBounciness.setValue(this.component.randomBounciness);
-		//this.splitParticle.setValue(this.component.splitParticleCount);
-		//this.splitParticleSpeedThreshold.setValue(this.component.splitParticleSpeedThreshold);
+		this.splitParticle.setValue(this.component.splitParticleCount);
+		this.splitParticleSpeedThreshold.setValue(this.component.splitParticleSpeedThreshold);
 		this.radius.setValue(this.component.radius);
 		this.expire.toggled(this.component.expireOnImpact);
 	}

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -16,6 +16,8 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	public GuiTrackpadElement drag;
 	public GuiTrackpadElement bounciness;
 	public GuiTrackpadElement randomBounciness;
+	public GuiTrackpadElement randomDamp;
+	public GuiTrackpadElement damp;
 	public GuiTrackpadElement splitParticle; //split particle into n particles on collision
 	public GuiTrackpadElement splitParticleSpeedThreshold;
 	public GuiTrackpadElement radius;
@@ -51,10 +53,24 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		
 		this.randomBounciness = new GuiTrackpadElement(mc, (value) ->
 		{
-			this.component.randomBounciness = (value<0) ? -value.floatValue() : value.floatValue();
+			this.component.randomBounciness = (float) Math.abs(value);
 			this.parent.dirty();
 		});
 		this.randomBounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomBounciness"));
+		
+		this.damp = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.damp = value.floatValue();
+			this.parent.dirty();
+		});
+		this.damp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.damp"));
+
+		this.randomDamp = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.randomDamp = (float) Math.abs(value);
+			this.parent.dirty();
+		});
+		this.randomDamp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomDamp"));
 		
 		this.splitParticleSpeedThreshold = new GuiTrackpadElement(mc, (value) ->
 		{
@@ -83,7 +99,8 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.splitParticle,  this.splitParticleSpeedThreshold, this.radius, this.expire);
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness,
+						this.damp, this.randomDamp, this.splitParticle,  this.splitParticleSpeedThreshold, this.radius, this.expire);
 	}
 
 	@Override
@@ -114,6 +131,8 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.drag.setValue(this.component.collissionDrag);
 		this.bounciness.setValue(this.component.bounciness);
 		this.randomBounciness.setValue(this.component.randomBounciness);
+		this.damp.setValue(this.component.damp);
+		this.randomDamp.setValue(this.component.randomDamp);
 		this.splitParticle.setValue(this.component.splitParticleCount);
 		this.splitParticleSpeedThreshold.setValue(this.component.splitParticleSpeedThreshold);
 		this.radius.setValue(this.component.radius);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -23,6 +23,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	public GuiTrackpadElement splitParticleSpeedThreshold;
 	public GuiTrackpadElement radius;
 	public GuiToggleElement expire;
+	public GuiTrackpadElement expirationDelay;
 
 	private boolean wasPresent;
 
@@ -99,8 +100,15 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.component.expireOnImpact = b.isToggled();
 			this.parent.dirty();
 		});
-
-		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.radius, this.expire,
+		
+		this.expirationDelay = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.expirationDelay = value.intValue();
+			this.parent.dirty();
+		});
+		this.expirationDelay.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.expirationDelay"));
+		
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.radius, this.expire, this.expirationDelay,
 						Elements.label(IKey.lang("blockbuster.gui.snowstorm.collision.damping.title"), 20).anchor(0, 1F), this.damp, this.randomDamp, 
 						Elements.label(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle.title"), 20).anchor(0, 1F), this.splitParticle,  this.splitParticleSpeedThreshold);
 	}
@@ -139,5 +147,6 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.splitParticleSpeedThreshold.setValue(this.component.splitParticleSpeedThreshold);
 		this.radius.setValue(this.component.radius);
 		this.expire.toggled(this.component.expireOnImpact);
+		this.expirationDelay.setValue(this.component.expirationDelay);
 	}
 }

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -179,6 +179,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.enabled.toggled(this.wasPresent);
 		this.realisticCollision.toggled(this.component.realisticCollision);
 		this.entityCollision.toggled(this.component.entityCollision);
+		this.momentum.toggled(this.component.momentum);
 		this.drag.setValue(this.component.collissionDrag);
 		this.bounciness.setValue(this.component.bounciness);
 		this.randomBounciness.setValue(this.component.randomBounciness);

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -7,6 +7,7 @@ import mchorse.blockbuster.client.particles.molang.MolangParser;
 import mchorse.mclib.client.gui.framework.elements.buttons.GuiToggleElement;
 import mchorse.mclib.client.gui.framework.elements.input.GuiTrackpadElement;
 import mchorse.mclib.client.gui.utils.keys.IKey;
+import mchorse.mclib.client.gui.utils.Elements;
 import net.minecraft.client.Minecraft;
 
 public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<BedrockComponentMotionCollision>
@@ -63,28 +64,28 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.component.damp = value.floatValue();
 			this.parent.dirty();
 		});
-		this.damp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.damp"));
-
+		this.damp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.damping.strength"));
+		
 		this.randomDamp = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.randomDamp = (float) Math.abs(value);
 			this.parent.dirty();
 		});
-		this.randomDamp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomDamp"));
+		this.randomDamp.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.damping.randomness"));
 		
 		this.splitParticleSpeedThreshold = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.splitParticleSpeedThreshold = value.floatValue();
 			this.parent.dirty();
 		});
-		this.splitParticleSpeedThreshold.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticleSpeedThreshold"));
+		this.splitParticleSpeedThreshold.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle.speedThreshold"));
 		
 		this.splitParticle = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.splitParticleCount = (int)Math.abs(value);
 			this.parent.dirty();
 		});
-		this.splitParticle.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle"));
+		this.splitParticle.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle.count"));
 		
 		this.radius = new GuiTrackpadElement(mc, (value) ->
 		{
@@ -99,8 +100,9 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness,
-						this.damp, this.randomDamp, this.splitParticle,  this.splitParticleSpeedThreshold, this.radius, this.expire);
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.radius, this.expire,
+						Elements.label(IKey.lang("blockbuster.gui.snowstorm.collision.damping.title"), 20).anchor(0, 1F), this.damp, this.randomDamp, 
+						Elements.label(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle.title"), 20).anchor(0, 1F), this.splitParticle,  this.splitParticleSpeedThreshold);
 	}
 
 	@Override

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -15,6 +15,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	public GuiToggleElement realisticCollision;
 	public GuiTrackpadElement drag;
 	public GuiTrackpadElement bounciness;
+	public GuiTrackpadElement randomBounciness;
 	public GuiTrackpadElement radius;
 	public GuiToggleElement expire;
 
@@ -42,6 +43,12 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 		this.bounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.bounciness"));
+		this.randomBounciness = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.randomBounciness = (value<0) ? -value.floatValue() : value.floatValue();
+			this.parent.dirty();
+		});
+		this.randomBounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomBounciness"));
 		this.radius = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.radius = value.floatValue();
@@ -54,7 +61,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.radius, this.expire);
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.radius, this.expire);
 	}
 
 	@Override
@@ -84,6 +91,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.realisticCollision.toggled(this.component.realisticCollision);
 		this.drag.setValue(this.component.collissionDrag);
 		this.bounciness.setValue(this.component.bounciness);
+		this.randomBounciness.setValue(this.component.randomBounciness);
 		this.radius.setValue(this.component.radius);
 		this.expire.toggled(this.component.expireOnImpact);
 	}

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -65,8 +65,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		
 		this.splitParticle = new GuiTrackpadElement(mc, (value) ->
 		{
-			this.component.splitParticleCount = (int)Math.round((value<0) ? -value : value);
-			//if(value!=0) this.fields.add(this.splitParticleSpeedThreshold);
+			this.component.splitParticleCount = (int)Math.abs(value);
 			this.parent.dirty();
 		});
 		this.splitParticle.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle"));
@@ -84,7 +83,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.splitParticle, this.radius, this.expire);
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.splitParticle,  this.splitParticleSpeedThreshold, this.radius, this.expire);
 	}
 
 	@Override

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -16,6 +16,8 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	public GuiTrackpadElement drag;
 	public GuiTrackpadElement bounciness;
 	public GuiTrackpadElement randomBounciness;
+	public GuiTrackpadElement splitParticle; //split particle into n particles on collision
+	public GuiTrackpadElement splitParticleSpeedThreshold;
 	public GuiTrackpadElement radius;
 	public GuiToggleElement expire;
 
@@ -26,42 +28,63 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		super(mc, parent);
 
 		this.enabled = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.enabled"), (b) -> this.parent.dirty());
+		
 		this.realisticCollision = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.realisticCollision"), (b) ->
 		{
 			this.component.realisticCollision = b.isToggled();
 			this.parent.dirty();
 		});
+		
 		this.drag = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.collissionDrag = value.floatValue();
 			this.parent.dirty();
 		});
 		this.drag.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.drag"));
+		
 		this.bounciness = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.bounciness = value.floatValue();
 			this.parent.dirty();
 		});
 		this.bounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.bounciness"));
+		
 		this.randomBounciness = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.randomBounciness = (value<0) ? -value.floatValue() : value.floatValue();
 			this.parent.dirty();
 		});
 		this.randomBounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomBounciness"));
+		
+		this.splitParticleSpeedThreshold = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.splitParticleSpeedThreshold = value.floatValue();
+			this.parent.dirty();
+		});
+		this.splitParticleSpeedThreshold.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticleSpeedThreshold"));
+		
+		this.splitParticle = new GuiTrackpadElement(mc, (value) ->
+		{
+			this.component.splitParticleCount = (int)Math.round((value<0) ? -value : value);
+			//if(value!=0) this.fields.add(this.splitParticleSpeedThreshold);
+			this.parent.dirty();
+		});
+		this.splitParticle.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.splitParticle"));
+		
 		this.radius = new GuiTrackpadElement(mc, (value) ->
 		{
 			this.component.radius = value.floatValue();
 			this.parent.dirty();
 		});
 		this.radius.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.radius"));
+		
 		this.expire = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.expire"), (b) ->
 		{
 			this.component.expireOnImpact = b.isToggled();
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.radius, this.expire);
+		this.fields.add(this.enabled, this.realisticCollision, this.drag, this.bounciness, this.randomBounciness, this.splitParticle, this.radius, this.expire);
 	}
 
 	@Override
@@ -92,6 +115,8 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 		this.drag.setValue(this.component.collissionDrag);
 		this.bounciness.setValue(this.component.bounciness);
 		this.randomBounciness.setValue(this.component.randomBounciness);
+		//this.splitParticle.setValue(this.component.splitParticleCount);
+		//this.splitParticleSpeedThreshold.setValue(this.component.splitParticleSpeedThreshold);
 		this.radius.setValue(this.component.radius);
 		this.expire.toggled(this.component.expireOnImpact);
 	}

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormCollisionSection.java
@@ -21,7 +21,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 	public GuiToggleElement momentum;
 	public GuiTrackpadElement drag;
 	public GuiTrackpadElement bounciness;
-	public GuiTrackpadElement randomBounciness;
+	public GuiTrackpadElement randomBounciness; //randomize the direction vector
 	public GuiToggleElement preserveEnergy;
 	public GuiTrackpadElement randomDamp;
 	public GuiTrackpadElement damp;
@@ -79,7 +79,7 @@ public class GuiSnowstormCollisionSection extends GuiSnowstormComponentSection<B
 			this.component.randomBounciness = (float) Math.abs(value);
 			this.parent.dirty();
 		});
-		this.randomBounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomBounciness"));
+		this.randomBounciness.tooltip(IKey.lang("blockbuster.gui.snowstorm.collision.randomDirection"));
 		
 		this.preserveEnergy = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.collision.preserveEnergy"), (b) -> this.parent.dirty());
 		

--- a/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormSpaceSection.java
+++ b/src/main/java/mchorse/blockbuster/client/gui/dashboard/panels/snowstorm/sections/GuiSnowstormSpaceSection.java
@@ -11,6 +11,9 @@ public class GuiSnowstormSpaceSection extends GuiSnowstormComponentSection<Bedro
 {
 	public GuiToggleElement position;
 	public GuiToggleElement rotation;
+	public GuiToggleElement direction; //local direction for physical accurate systems
+	public GuiToggleElement acceleration;
+	public GuiToggleElement gravity;
 
 	public GuiSnowstormSpaceSection(Minecraft mc, GuiSnowstorm parent)
 	{
@@ -28,7 +31,23 @@ public class GuiSnowstormSpaceSection extends GuiSnowstormComponentSection<Bedro
 			this.parent.dirty();
 		});
 
-		this.fields.add(this.position, this.rotation);
+		this.direction = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.space.direction"), (b) ->
+		{
+			this.component.direction = b.isToggled();
+			this.parent.dirty();
+		});
+		this.acceleration = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.space.acceleration"), (b) ->
+		{
+			this.component.acceleration = b.isToggled();
+			this.parent.dirty();
+		});
+		this.gravity = new GuiToggleElement(mc, IKey.lang("blockbuster.gui.snowstorm.space.gravity"), (b) ->
+		{
+			this.component.gravity = b.isToggled();
+			this.parent.dirty();
+		});
+
+		this.fields.add(this.position, this.rotation, this.direction, this.acceleration, this.gravity);
 	}
 
 	@Override
@@ -48,5 +67,8 @@ public class GuiSnowstormSpaceSection extends GuiSnowstormComponentSection<Bedro
 	{
 		this.position.toggled(this.component.position);
 		this.rotation.toggled(this.component.rotation);
+		this.direction.toggled(this.component.direction);
+		this.acceleration.toggled(this.component.acceleration);
+		this.gravity.toggled(this.component.gravity);
 	}
 }

--- a/src/main/java/mchorse/blockbuster/client/particles/BedrockSchemeJsonAdapter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/BedrockSchemeJsonAdapter.java
@@ -15,6 +15,7 @@ import mchorse.blockbuster.client.particles.components.appearance.BedrockCompone
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceLighting;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceTinting;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionTinting;
 import mchorse.blockbuster.client.particles.components.expiration.BedrockComponentExpireInBlocks;
 import mchorse.blockbuster.client.particles.components.expiration.BedrockComponentExpireNotInBlocks;
 import mchorse.blockbuster.client.particles.components.expiration.BedrockComponentKillPlane;
@@ -107,7 +108,8 @@ public class BedrockSchemeJsonAdapter implements JsonDeserializer<BedrockScheme>
 		this.components.put("minecraft:particle_appearance_lighting", BedrockComponentAppearanceLighting.class);
 		this.components.put("minecraft:particle_appearance_tinting", BedrockComponentAppearanceTinting.class);
 		this.components.put("minecraft:particle_collision_appearance", BedrockComponentCollisionAppearance.class);
-
+		this.components.put("minecraft:particle_collision_tinting", BedrockComponentCollisionTinting.class);
+		
 		/* Motion & Rotation */
 		this.components.put("minecraft:particle_initial_speed", BedrockComponentInitialSpeed.class);
 		this.components.put("minecraft:particle_initial_spin", BedrockComponentInitialSpin.class);

--- a/src/main/java/mchorse/blockbuster/client/particles/BedrockSchemeJsonAdapter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/BedrockSchemeJsonAdapter.java
@@ -14,6 +14,7 @@ import mchorse.blockbuster.client.particles.components.BedrockComponentBase;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceBillboard;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceLighting;
 import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentAppearanceTinting;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
 import mchorse.blockbuster.client.particles.components.expiration.BedrockComponentExpireInBlocks;
 import mchorse.blockbuster.client.particles.components.expiration.BedrockComponentExpireNotInBlocks;
 import mchorse.blockbuster.client.particles.components.expiration.BedrockComponentKillPlane;
@@ -105,6 +106,7 @@ public class BedrockSchemeJsonAdapter implements JsonDeserializer<BedrockScheme>
 		this.components.put("minecraft:particle_appearance_billboard", BedrockComponentAppearanceBillboard.class);
 		this.components.put("minecraft:particle_appearance_lighting", BedrockComponentAppearanceLighting.class);
 		this.components.put("minecraft:particle_appearance_tinting", BedrockComponentAppearanceTinting.class);
+		this.components.put("minecraft:particle_collision_appearance", BedrockComponentCollisionAppearance.class);
 
 		/* Motion & Rotation */
 		this.components.put("minecraft:particle_initial_speed", BedrockComponentInitialSpeed.class);

--- a/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionAppearance.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionAppearance.java
@@ -304,20 +304,22 @@ public class BedrockComponentCollisionAppearance extends BedrockComponentBase im
 	public void render(BedrockEmitter emitter, BedrockParticle particle, BufferBuilder builder, float partialTicks)
 	{
 		boolean tmpLit = false;
-		if(!particle.collisionTexture) {
-			if(particle.collisionTinting) {
+		if(!particle.collisionTexture) 
+		{
+			if(particle.collisionTinting) 
+			{
 				tmpLit = emitter.lit;
 				emitter.lit = this.lit;
 				emitter.scheme.get(BedrockComponentAppearanceBillboard.class).render(emitter, particle, builder, partialTicks);
 				emitter.lit = tmpLit;
 			}
-			return;
+			return; //when texture and tinting is false - this render method should not be used
 		}
-		else {
-			if(!particle.collisionTinting) {
-				tmpLit = this.lit;
-				this.lit = emitter.lit;
-			}
+		else if(!particle.collisionTinting) 
+		{
+			//tinting false doesn't necessarily mean that lit was not passed - emitter.lit should be used
+			tmpLit = this.lit;
+			this.lit = emitter.lit;
 		}
 		GifTexture.bindTexture(this.texture, emitter.age, partialTicks);
 		
@@ -422,7 +424,7 @@ public class BedrockComponentCollisionAppearance extends BedrockComponentBase im
 		}
 	}
 
-	@Override
+	@Override //not really important because it seems to be used for guiParticles - there is no collision
 	public void renderOnScreen(BedrockParticle particle, int x, int y, float scale, float partialTicks)
 	{
 		if(!particle.collisionTexture) return;

--- a/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionAppearance.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionAppearance.java
@@ -484,8 +484,8 @@ public class BedrockComponentCollisionAppearance extends BedrockComponentBase im
 
 			if (this.stretchFPS)
 			{
-				float lifetime = particle.lifetime <= 0 ? 0 : (particle.age + partialTicks) / particle.lifetime;
-
+				float lifetime = (particle.lifetime <= 0) ? 0 : (particle.age + partialTicks) / (particle.lifetime-particle.firstCollision);
+				if(particle.expireAge!=0) lifetime = (particle.lifetime <= 0) ? 0 : (particle.age + partialTicks) / (particle.expirationDelay);
 				index = (int) (lifetime * max);
 			}
 

--- a/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionAppearance.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionAppearance.java
@@ -1,0 +1,488 @@
+package mchorse.blockbuster.client.particles.components.appearance;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import mchorse.blockbuster.Blockbuster;
+import mchorse.blockbuster.client.particles.BedrockMaterial;
+import mchorse.blockbuster.client.particles.BedrockScheme;
+import mchorse.blockbuster.client.particles.components.BedrockComponentBase;
+import mchorse.blockbuster.client.particles.components.IComponentParticleRender;
+import mchorse.blockbuster.client.particles.emitter.BedrockEmitter;
+import mchorse.blockbuster.client.particles.emitter.BedrockParticle;
+import mchorse.blockbuster.client.particles.molang.MolangException;
+import mchorse.blockbuster.client.particles.molang.MolangParser;
+import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
+import mchorse.blockbuster.client.textures.GifTexture;
+import mchorse.mclib.utils.Interpolations;
+import mchorse.mclib.utils.resources.RLUtils;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+
+import javax.vecmath.Matrix4f;
+import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
+
+public class BedrockComponentCollisionAppearance extends BedrockComponentBase implements IComponentParticleRender
+{
+	/* Options */
+	public static final ResourceLocation DEFAULT_TEXTURE = new ResourceLocation(Blockbuster.MOD_ID, "textures/default_particles.png");
+	public BedrockMaterial material = BedrockMaterial.OPAQUE;
+	public ResourceLocation texture = DEFAULT_TEXTURE;
+	
+	public MolangExpression sizeW = MolangParser.ZERO;
+	public MolangExpression sizeH = MolangParser.ZERO;
+	public CameraFacing facing = CameraFacing.LOOKAT_XYZ;
+	public int textureWidth = 128;
+	public int textureHeight = 128;
+	public MolangExpression uvX = MolangParser.ZERO;
+	public MolangExpression uvY = MolangParser.ZERO;
+	public MolangExpression uvW = MolangParser.ZERO;
+	public MolangExpression uvH = MolangParser.ZERO;
+
+	public boolean flipbook = false;
+	public float stepX;
+	public float stepY;
+	public float fps;
+	public MolangExpression maxFrame = MolangParser.ZERO;
+	public boolean stretchFPS = false;
+	public boolean loop = false;
+
+	/* Runtime properties */
+	private float w;
+	private float h;
+
+	private float u1;
+	private float v1;
+	private float u2;
+	private float v2;
+
+	private Matrix4f transform = new Matrix4f();
+	private Matrix4f rotation = new Matrix4f();
+	private Vector4f[] vertices = new Vector4f[] {
+		new Vector4f(0, 0, 0, 1),
+		new Vector4f(0, 0, 0, 1),
+		new Vector4f(0, 0, 0, 1),
+		new Vector4f(0, 0, 0, 1)
+	};
+	private Vector3f vector = new Vector3f();
+	
+	public BedrockComponentCollisionAppearance() {};
+	
+	@Override
+	public BedrockComponentBase fromJson(JsonElement elem, MolangParser parser) throws MolangException
+	{
+		if (!elem.isJsonObject()) return super.fromJson(elem, parser);
+
+		JsonObject element = elem.getAsJsonObject();
+
+		if (element.has("material"))
+		{
+			this.material = BedrockMaterial.fromString(element.get("material").getAsString());
+		}
+		
+		if(element.has("texture")) 
+		{
+			String texture = element.get("texture").getAsString();
+
+			if (!texture.equals("textures/particle/particles"))
+			{
+				this.texture = RLUtils.create(texture);
+			}
+		}
+		if (element.has("size") && element.get("size").isJsonArray())
+		{
+			JsonArray size = element.getAsJsonArray("size");
+
+			if (size.size() >= 2)
+			{
+				this.sizeW = parser.parseJson(size.get(0));
+				this.sizeH = parser.parseJson(size.get(1));
+			}
+		}
+
+		if (element.has("facing_camera_mode"))
+		{
+			this.facing = CameraFacing.fromString(element.get("facing_camera_mode").getAsString());
+		}
+
+		if (element.has("uv") && element.get("uv").isJsonObject())
+		{
+			this.parseUv(element.get("uv").getAsJsonObject(), parser);
+		}
+
+		return super.fromJson(element, parser);
+	}
+
+	private void parseUv(JsonObject object, MolangParser parser) throws MolangException
+	{
+		if (object.has("texture_width")) this.textureWidth = object.get("texture_width").getAsInt();
+		if (object.has("texture_height")) this.textureHeight = object.get("texture_height").getAsInt();
+
+		if (object.has("uv") && object.get("uv").isJsonArray())
+		{
+			JsonArray uv = object.getAsJsonArray("uv");
+
+			if (uv.size() >= 2)
+			{
+				this.uvX = parser.parseJson(uv.get(0));
+				this.uvY = parser.parseJson(uv.get(1));
+			}
+		}
+
+		if (object.has("uv_size") && object.get("uv_size").isJsonArray())
+		{
+			JsonArray uv = object.getAsJsonArray("uv_size");
+
+			if (uv.size() >= 2)
+			{
+				this.uvW = parser.parseJson(uv.get(0));
+				this.uvH = parser.parseJson(uv.get(1));
+			}
+		}
+
+		if (object.has("flipbook") && object.get("flipbook").isJsonObject())
+		{
+			this.flipbook = true;
+			this.parseFlipbook(object.get("flipbook").getAsJsonObject(), parser);
+		}
+	}
+
+	private void parseFlipbook(JsonObject flipbook, MolangParser parser) throws MolangException
+	{
+		if (flipbook.has("base_UV") && flipbook.get("base_UV").isJsonArray())
+		{
+			JsonArray uv = flipbook.getAsJsonArray("base_UV");
+
+			if (uv.size() >= 2)
+			{
+				this.uvX = parser.parseJson(uv.get(0));
+				this.uvY = parser.parseJson(uv.get(1));
+			}
+		}
+
+		if (flipbook.has("size_UV") && flipbook.get("size_UV").isJsonArray())
+		{
+			JsonArray uv = flipbook.getAsJsonArray("size_UV");
+
+			if (uv.size() >= 2)
+			{
+				this.uvW = parser.parseJson(uv.get(0));
+				this.uvH = parser.parseJson(uv.get(1));
+			}
+		}
+
+		if (flipbook.has("step_UV") && flipbook.get("step_UV").isJsonArray())
+		{
+			JsonArray uv = flipbook.getAsJsonArray("step_UV");
+
+			if (uv.size() >= 2)
+			{
+				this.stepX = uv.get(0).getAsFloat();
+				this.stepY = uv.get(1).getAsFloat();
+			}
+		}
+
+		if (flipbook.has("frames_per_second")) this.fps = flipbook.get("frames_per_second").getAsFloat();
+		if (flipbook.has("max_frame")) this.maxFrame = parser.parseJson(flipbook.get("max_frame"));
+		if (flipbook.has("stretch_to_lifetime")) this.stretchFPS = flipbook.get("stretch_to_lifetime").getAsBoolean();
+		if (flipbook.has("loop")) this.loop = flipbook.get("loop").getAsBoolean();
+	}
+
+	@Override
+	public JsonElement toJson()
+	{
+		JsonObject object = new JsonObject();
+		JsonArray size = new JsonArray();
+		JsonObject uv = new JsonObject();
+
+		size.add(this.sizeW.toJson());
+		size.add(this.sizeH.toJson());
+
+		/* Adding "uv" properties */
+		uv.addProperty("texture_width", this.textureWidth);
+		uv.addProperty("texture_height", this.textureHeight);
+
+		object.addProperty("material", this.material.id);
+		
+		if(this.texture != null && !this.texture.equals(BedrockScheme.DEFAULT_TEXTURE)) 
+		{
+			object.addProperty("texture", this.texture.toString());
+		}
+		
+		if (!this.flipbook && !MolangExpression.isZero(this.uvX) || !MolangExpression.isZero(this.uvY))
+		{
+			JsonArray uvs = new JsonArray();
+			uvs.add(this.uvX.toJson());
+			uvs.add(this.uvY.toJson());
+
+			uv.add("uv", uvs);
+		}
+
+		if (!this.flipbook && !MolangExpression.isZero(this.uvW) || !MolangExpression.isZero(this.uvH))
+		{
+			JsonArray uvs = new JsonArray();
+			uvs.add(this.uvW.toJson());
+			uvs.add(this.uvH.toJson());
+
+			uv.add("uv_size", uvs);
+		}
+
+		/* Adding "flipbook" properties to "uv" */
+		if (this.flipbook)
+		{
+			JsonObject flipbook = new JsonObject();
+
+			if (!MolangExpression.isZero(this.uvX) || !MolangExpression.isZero(this.uvY))
+			{
+				JsonArray base = new JsonArray();
+				base.add(this.uvX.toJson());
+				base.add(this.uvY.toJson());
+
+				flipbook.add("base_UV", base);
+			}
+
+			if (!MolangExpression.isZero(this.uvW) || !MolangExpression.isZero(this.uvH))
+			{
+				JsonArray uvSize = new JsonArray();
+				uvSize.add(this.uvW.toJson());
+				uvSize.add(this.uvH.toJson());
+
+				flipbook.add("size_UV", uvSize);
+			}
+
+			if (this.stepX != 0 || this.stepY != 0)
+			{
+				JsonArray step = new JsonArray();
+				step.add(this.stepX);
+				step.add(this.stepY);
+
+				flipbook.add("step_UV", step);
+			}
+
+			if (this.fps != 0) flipbook.addProperty("frames_per_second", this.fps);
+			if (!MolangExpression.isZero(this.maxFrame)) flipbook.add("max_frame", this.maxFrame.toJson());
+			if (this.stretchFPS) flipbook.addProperty("stretch_to_lifetime", true);
+			if (this.loop) flipbook.addProperty("loop", true);
+
+			uv.add("flipbook", flipbook);
+		}
+
+		/* Add main properties */
+		object.add("size", size);
+		object.addProperty("facing_camera_mode", this.facing.id);
+		object.add("uv", uv);
+
+		return object;
+	}
+
+	@Override
+	public void preRender(BedrockEmitter emitter, float partialTicks)
+	{}
+
+	@Override
+	public void render(BedrockEmitter emitter, BedrockParticle particle, BufferBuilder builder, float partialTicks)
+	{
+		if(!particle.collisionTexture) return;
+		//GifTexture.bindTexture(this.texture, emitter.age, partialTicks);
+		
+		this.calculateUVs(particle, partialTicks);
+
+		/* Render the particle */
+		double px = Interpolations.lerp(particle.prevPosition.x, particle.position.x, partialTicks);
+		double py = Interpolations.lerp(particle.prevPosition.y, particle.position.y, partialTicks);
+		double pz = Interpolations.lerp(particle.prevPosition.z, particle.position.z, partialTicks);
+		float angle = Interpolations.lerp(particle.prevRotation, particle.rotation, partialTicks);
+
+		if (particle.relativePosition && particle.relativeRotation)
+		{
+			this.vector.set((float) px, (float) py, (float) pz);
+			emitter.rotation.transform(this.vector);
+
+			px = this.vector.x;
+			py = this.vector.y;
+			pz = this.vector.z;
+
+			px += emitter.lastGlobal.x;
+			py += emitter.lastGlobal.y;
+			pz += emitter.lastGlobal.z;
+		}
+
+		/* Calculate yaw and pitch based on the facing mode */
+		float entityYaw = emitter.cYaw;
+		float entityPitch = emitter.cPitch;
+		double entityX = emitter.cX;
+		double entityY = emitter.cY;
+		double entityZ = emitter.cZ;
+		boolean lookAt = this.facing == CameraFacing.LOOKAT_XYZ || this.facing == CameraFacing.LOOKAT_Y;
+
+		/* Flip width when frontal perspective mode */
+		if (emitter.perspective == 2)
+		{
+			this.w = -this.w;
+		}
+		/* In GUI renderer */
+		else if (emitter.perspective == 100 && !lookAt)
+		{
+			entityYaw = 180 - entityYaw;
+
+			this.w = -this.w;
+			this.h = -this.h;
+		}
+
+		if (lookAt)
+		{
+			double dX = entityX - px;
+			double dY = entityY - py;
+			double dZ = entityZ - pz;
+			double horizontalDistance = MathHelper.sqrt(dX * dX + dZ * dZ);
+
+			entityYaw = 180 - (float) (MathHelper.atan2(dZ, dX) * (180D / Math.PI)) - 90.0F;
+			entityPitch = (float) (-(MathHelper.atan2(dY, horizontalDistance) * (180D / Math.PI))) + 180;
+		}
+
+		/* Calculate the geometry for billboards using cool matrix math */
+		int light = emitter.getBrightnessForRender(partialTicks, px, py, pz);
+		int lightX = light >> 16 & 65535;
+		int lightY = light & 65535;
+
+		this.vertices[0].set(-this.w / 2, -this.h / 2, 0, 1);
+		this.vertices[1].set(this.w / 2, -this.h / 2, 0, 1);
+		this.vertices[2].set(this.w / 2, this.h / 2, 0, 1);
+		this.vertices[3].set(-this.w / 2, this.h / 2, 0, 1);
+		this.transform.setIdentity();
+
+		if (this.facing == CameraFacing.ROTATE_XYZ || this.facing == CameraFacing.LOOKAT_XYZ)
+		{
+			this.rotation.rotY(entityYaw / 180 * (float) Math.PI);
+			this.transform.mul(this.rotation);
+			this.rotation.rotX(entityPitch / 180 * (float) Math.PI);
+			this.transform.mul(this.rotation);
+		}
+		else if (this.facing == CameraFacing.ROTATE_Y || this.facing == CameraFacing.LOOKAT_Y) {
+			this.rotation.rotY(entityYaw / 180 * (float) Math.PI);
+			this.transform.mul(this.rotation);
+		}
+
+		this.rotation.rotZ(angle / 180 * (float) Math.PI);
+		this.transform.mul(this.rotation);
+		this.transform.setTranslation(new Vector3f((float) px, (float) py, (float) pz));
+
+		for (Vector4f vertex : this.vertices)
+		{
+			this.transform.transform(vertex);
+		}
+
+		float u1 = this.u1 / (float) this.textureWidth;
+		float u2 = this.u2 / (float) this.textureWidth;
+		float v1 = this.v1 / (float) this.textureHeight;
+		float v2 = this.v2 / (float) this.textureHeight;
+
+		builder.pos(this.vertices[0].x, this.vertices[0].y, this.vertices[0].z).tex(u1, v1).lightmap(lightX, lightY).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+		builder.pos(this.vertices[1].x, this.vertices[1].y, this.vertices[1].z).tex(u2, v1).lightmap(lightX, lightY).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+		builder.pos(this.vertices[2].x, this.vertices[2].y, this.vertices[2].z).tex(u2, v2).lightmap(lightX, lightY).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+		builder.pos(this.vertices[3].x, this.vertices[3].y, this.vertices[3].z).tex(u1, v2).lightmap(lightX, lightY).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+	}
+
+	@Override
+	public void renderOnScreen(BedrockParticle particle, int x, int y, float scale, float partialTicks)
+	{
+		if(!particle.collisionTexture) return;
+		this.calculateUVs(particle, partialTicks);
+
+		this.w = this.h = 0.5F;
+		float angle = Interpolations.lerp(particle.prevRotation, particle.rotation, partialTicks);
+
+		/* Calculate the geometry for billboards using cool matrix math */
+		this.vertices[0].set(-this.w / 2, -this.h / 2, 0, 1);
+		this.vertices[1].set(this.w / 2, -this.h / 2, 0, 1);
+		this.vertices[2].set(this.w / 2, this.h / 2, 0, 1);
+		this.vertices[3].set(-this.w / 2, this.h / 2, 0, 1);
+		this.transform.setIdentity();
+		this.transform.setScale(scale * 2.75F);
+		this.transform.setTranslation(new Vector3f(x, y - scale / 2, 0));
+
+		this.rotation.rotZ(angle / 180 * (float) Math.PI);
+		this.transform.mul(this.rotation);
+
+		for (Vector4f vertex : this.vertices)
+		{
+			this.transform.transform(vertex);
+		}
+
+		float u1 = this.u1 / (float) this.textureWidth;
+		float u2 = this.u2 / (float) this.textureWidth;
+		float v1 = this.v1 / (float) this.textureHeight;
+		float v2 = this.v2 / (float) this.textureHeight;
+
+		BufferBuilder builder = Tessellator.getInstance().getBuffer();
+
+		builder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
+		builder.pos(this.vertices[0].x, this.vertices[0].y, this.vertices[0].z).tex(u1, v1).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+		builder.pos(this.vertices[1].x, this.vertices[1].y, this.vertices[1].z).tex(u2, v1).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+		builder.pos(this.vertices[2].x, this.vertices[2].y, this.vertices[2].z).tex(u2, v2).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+		builder.pos(this.vertices[3].x, this.vertices[3].y, this.vertices[3].z).tex(u1, v2).color(particle.r, particle.g, particle.b, particle.a).endVertex();
+
+		Tessellator.getInstance().draw();
+	}
+
+	public void calculateUVs(BedrockParticle particle, float partialTicks)
+	{
+		/* Update particle's UVs and size */
+		this.w = (float) this.sizeW.get() * 2.25F;
+		this.h = (float) this.sizeH.get() * 2.25F;
+
+		float u = (float) this.uvX.get();
+		float v = (float) this.uvY.get();
+		float w = (float) this.uvW.get();
+		float h = (float) this.uvH.get();
+
+		if (this.flipbook)
+		{
+			int index = (int) (particle.getAge(partialTicks) * this.fps);
+			int max = (int) this.maxFrame.get();
+
+			if (this.stretchFPS)
+			{
+				float lifetime = particle.lifetime <= 0 ? 0 : (particle.age + partialTicks) / particle.lifetime;
+
+				index = (int) (lifetime * max);
+			}
+
+			if (this.loop && max != 0)
+			{
+				index = index % max;
+			}
+
+			if (index > max)
+			{
+				index = max;
+			}
+
+			u += this.stepX * index;
+			v += this.stepY * index;
+		}
+
+		this.u1 = u;
+		this.v1 = v;
+		this.u2 = u + w;
+		this.v2 = v + h;
+	}
+
+	@Override
+	public void postRender(BedrockEmitter emitter, float partialTicks)
+	{}
+	
+	@Override
+	public int getSortingIndex()
+	{
+		return 200;
+	}
+}

--- a/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionTinting.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/appearance/BedrockComponentCollisionTinting.java
@@ -1,0 +1,94 @@
+package mchorse.blockbuster.client.particles.components.appearance;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import mchorse.blockbuster.client.particles.BedrockSchemeJsonAdapter;
+import mchorse.blockbuster.client.particles.components.BedrockComponentBase;
+import mchorse.blockbuster.client.particles.components.IComponentParticleRender;
+import mchorse.blockbuster.client.particles.emitter.BedrockEmitter;
+import mchorse.blockbuster.client.particles.emitter.BedrockParticle;
+import mchorse.blockbuster.client.particles.molang.MolangException;
+import mchorse.blockbuster.client.particles.molang.MolangParser;
+import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
+import net.minecraft.client.renderer.BufferBuilder;
+
+public class BedrockComponentCollisionTinting extends BedrockComponentBase implements IComponentParticleRender
+{
+	public MolangExpression enabled = MolangParser.ZERO;
+	public Tint color = new Tint.Solid(MolangParser.ONE, MolangParser.ONE, MolangParser.ONE, MolangParser.ONE);
+
+	@Override
+	public BedrockComponentBase fromJson(JsonElement elem, MolangParser parser) throws MolangException
+	{
+		if (!elem.isJsonObject()) return super.fromJson(elem, parser);
+
+		JsonObject element = elem.getAsJsonObject();
+		if (element.has("enabled")) this.enabled = parser.parseJson(element.get("enabled"));
+		if (element.has("color"))
+		{
+			JsonElement color = element.get("color");
+
+			if (color.isJsonArray() || color.isJsonPrimitive())
+			{
+				this.color = Tint.parseColor(color, parser);
+			}
+			else if (color.isJsonObject())
+			{
+				this.color = Tint.parseGradient(color.getAsJsonObject(), parser);
+			}
+		}
+
+		return super.fromJson(element, parser);
+	}
+
+	@Override
+	public JsonElement toJson()
+	{
+		JsonObject object = new JsonObject();
+		JsonElement element = this.color.toJson();
+		
+		object.add("enabled", this.enabled.toJson());
+		
+		if (!BedrockSchemeJsonAdapter.isEmpty(element))
+		{
+			object.add("color", element);
+		}
+
+		return object;
+	}
+
+	/* Interface implementations */
+
+	@Override
+	public void preRender(BedrockEmitter emitter, float partialTicks)
+	{}
+
+	@Override
+	public void render(BedrockEmitter emitter, BedrockParticle particle, BufferBuilder builder, float partialTicks)
+	{
+		if(particle.collisionTinting) this.renderOnScreen(particle, 0, 0, 0, 0);
+	}
+
+	@Override
+	public void renderOnScreen(BedrockParticle particle, int x, int y, float scale, float partialTicks)
+	{
+		if (this.color != null)
+		{
+			this.color.compute(particle);
+		}
+		else
+		{
+			particle.r = particle.g = particle.b = particle.a = 1;
+		}
+	}
+
+	@Override
+	public void postRender(BedrockEmitter emitter, float partialTicks)
+	{}
+
+	@Override
+	public int getSortingIndex()
+	{
+		return -5;
+	}
+}

--- a/src/main/java/mchorse/blockbuster/client/particles/components/meta/BedrockComponentLocalSpace.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/meta/BedrockComponentLocalSpace.java
@@ -13,7 +13,10 @@ public class BedrockComponentLocalSpace extends BedrockComponentBase implements 
 {
 	public boolean position;
 	public boolean rotation;
-
+	public boolean direction;
+	public boolean acceleration;
+	public boolean gravity;
+	
 	public BedrockComponentBase fromJson(JsonElement elem, MolangParser parser) throws MolangException
 	{
 		if (!elem.isJsonObject()) return super.fromJson(elem, parser);
@@ -22,7 +25,10 @@ public class BedrockComponentLocalSpace extends BedrockComponentBase implements 
 
 		if (element.has("position")) this.position = element.get("position").getAsBoolean();
 		if (element.has("rotation")) this.rotation = element.get("rotation").getAsBoolean();
-
+		if (element.has("direction")) this.direction = element.get("direction").getAsBoolean();
+		if (element.has("acceleration")) this.acceleration = element.get("acceleration").getAsBoolean();
+		if (element.has("gravity")) this.gravity = element.get("gravity").getAsBoolean();
+		
 		return super.fromJson(element, parser);
 	}
 
@@ -33,7 +39,10 @@ public class BedrockComponentLocalSpace extends BedrockComponentBase implements 
 
 		if (this.position) object.addProperty("position", true);
 		if (this.rotation) object.addProperty("rotation", true);
-
+		if (this.direction) object.addProperty("direction", true);
+		if (this.acceleration) object.addProperty("acceleration", true);
+		if (this.gravity) object.addProperty("gravity", true);
+		
 		return object;
 	}
 
@@ -42,7 +51,10 @@ public class BedrockComponentLocalSpace extends BedrockComponentBase implements 
 	{
 		particle.relativePosition = this.position;
 		particle.relativeRotation = this.rotation;
-
+		particle.relativeDirection = this.direction;
+		particle.relativeAcceleration = this.acceleration;
+		particle.gravity = this.gravity;
+		
 		particle.setupMatrix(emitter);
 	}
 

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -149,7 +149,6 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			//for own hitbox implementation: check for hitbox expanded for the previous position - prevent fast moving tunneling
 			List<AxisAlignedBB> list = emitter.world.getCollisionBoxes(null, aabb.expand(x, y, z));
 			
-			boolean lazy = false;
 			if(this.entityCollision) 
 			{
 				for(Entity entity : entities) 
@@ -187,11 +186,11 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						Vector3d frac = intersect(ray, particle.getGlobalPosition(emitter), entityAABB);
 
 						if(frac!=null) {
-							//lazy = true;
 							frac.scale(1);
 
 							particle.position.add(frac);
 							
+							//recalculate the variables
 							prev.set(particle.getGlobalPosition(emitter));
 							//frac.scale(particle.speed.length()/frac.length());
 							//prev.x += frac.x;
@@ -215,14 +214,13 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 							try {
 								if((aabb.minX<entityAABB.maxX && aabb.maxX>entityAABB.maxX) || (aabb.maxX>entityAABB.minX && aabb.minX<entityAABB.minX))
 								{
-									//float tmpSpeed = particle.speed.x;
-									float tmpTime = particle.collisionTime.x; //collisionTime should be not changed - otherwise the particles will stop when moving against them
+									float tmpTime = particle.collisionTime.x; //collisionTime should be not changed - otherwise the particles will stop when moving against moving entites
 									double delta = particle.position.x-entity.posX;
 									particle.position.x += delta>0 ? r : -r;
 									collisionHandler(particle, emitter, 'x', particle.position, prev, entities);
 									particle.collisionTime.x = tmpTime;
 									
-									//particle speed is always switched, as it always collides with the entity, but it should only remain one correct direction
+									//particle speed is always switched (realistcCollision==true), as it always collides with the entity, but it should only have one correct direction
 									if(particle.speed.x>0) {
 										if(speedEntity.x<0) particle.speed.x = -particle.speed.x;
 									}

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -224,7 +224,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				{
 					if(this.expirationDelay.get()!=0 && particle.expireAge==0)
 					{
-						particle.expireAge = (int) (particle.age+MathUtils.clamp(this.expirationDelay.get(), 0, 1));
+						particle.expireAge = (int) (particle.age+Math.abs(this.expirationDelay.get()));
 						particle.expirationDelay = (int) this.expirationDelay.get();
 					}
 					else if(this.expirationDelay.get()==0)

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -140,6 +140,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			double d0 = y;
 			double origX = x;
 			double origZ = z;
+			
 			List<Entity> list2 = emitter.world.getEntitiesWithinAABB(Entity.class, aabb.expand(x, y, z));
 			List<AxisAlignedBB> list = emitter.world.getCollisionBoxes(null, aabb.expand(x, y, z));
 
@@ -296,9 +297,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 		if(this.momentum && this.entityCollision) { //NOT FINISHED
 			for(Entity entity : entities) 
 			{
-				particle.speed.x += entity.posX-entity.prevPosX;
-				particle.speed.y += entity.posY-entity.prevPosY;
-				particle.speed.z += entity.posZ-entity.prevPosZ;
+				particle.speed.x += 2*(entity.posX-entity.prevPosX);
+				particle.speed.y += 2*(entity.posY-entity.prevPosY);
+				particle.speed.z += 2*(entity.posZ-entity.prevPosZ);
 			}
 		}
 		
@@ -307,8 +308,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 	
 	public Vector3f damping(Vector3f vector) 
 	{
-		float randomDamp = (this.randomDamp*0.1f)/2;
-		float random = (float) (randomDamp*(Math.random()*2-1));
+		float random = (float) (this.randomDamp*(Math.random()*2-1));
 		float clampedValue = Math.max(0, Math.min(1, (1-damp)+random)); //clamp between 0 and 1
 		vector.scale(clampedValue);
 		return vector;
@@ -325,7 +325,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			splitParticle.collisionTime.set(particle.collisionTime);
 			splitParticle.position.set(now);
 			splitParticle.prevPosition.set(prev);
-			
+
 			//Mh is this necessary?
 			splitParticle.acceleration.set(particle.acceleration);
 			splitParticle.accelerationFactor.set(particle.accelerationFactor);

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -142,6 +142,38 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			double origZ = z;
 			
 			List<Entity> list2 = emitter.world.getEntitiesWithinAABB(Entity.class, aabb.expand(x, y, z));
+			//for own hitbox implementation: check for hitbox expanded for the previous position - prevent fast moving tunneling
+			/*for(Entity entity : list2) 
+			{
+				AxisAlignedBB axisalignedbb = entity.getEntityBoundingBox();
+				Vector3f speedEntity = new Vector3f();
+				speedEntity.x = (float)entity.motionX;
+				speedEntity.y = (float)entity.motionY;
+				speedEntity.z = (float)entity.motionZ;
+				
+				Vector3f speedParticle = particle.speed;
+				Vector3f ray = particle.speed;
+				if(Math.round(speedParticle.dot(speedEntity))==0) {
+					ray = speedEntity;
+				}
+				
+
+				Vector3d ray0 = intersect(ray, particle.getGlobalPosition(emitter), axisalignedbb);
+				if(ray0!=null) {
+					
+					particle.position.add(ray0);
+					now = particle.getGlobalPosition(emitter);
+
+					x = now.x - prev.x;
+					y = now.y - prev.y;
+					z = now.z - prev.z;
+					aabb = new AxisAlignedBB(prev.x - r, prev.y - r, prev.z - r, prev.x + r, prev.y + r, prev.z + r);
+
+					d0 = y;
+					origX = x;
+					origZ = z;
+				}
+			}*/
 			List<AxisAlignedBB> list = emitter.world.getCollisionBoxes(null, aabb.expand(x, y, z));
 
 			if(this.entityCollision) 
@@ -436,6 +468,65 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 		}
 		return vector0;
 	}
+	
+	public Vector3d intersect(Vector3f ray, Vector3d orig, AxisAlignedBB aabb) 
+	{ 
+		double tmin = (aabb.minX - orig.x) / ray.x; 
+	    double tmax = (aabb.maxX - orig.x) / ray.x; 
+	 
+	    if (tmin > tmax) {
+	    	double tminTmp = tmin;
+	    	tmin = tmax;
+	    	tmax = tminTmp;
+	    }
+	 
+	    double tymin = (aabb.minY - orig.y) / ray.y; 
+	    double tymax = (aabb.maxY - orig.y) / ray.y; 
+	 
+	    if (tymin > tymax) {
+	    	double tyminTmp = tymin;
+	    	tymin = tymax;
+	    	tymax = tyminTmp;
+	    }
+	 
+	    if ((tmin > tymax) || (tymin > tmax)) 
+	        return null; 
+	 
+	    if (tymin > tmin) 
+	        tmin = tymin; 
+	 
+	    if (tymax < tmax) 
+	        tmax = tymax; 
+	 
+	    double tzmin = (aabb.minZ - orig.z) / ray.z; 
+	    double tzmax = (aabb.maxZ - orig.z) / ray.z; 
+	 
+	    if (tzmin > tzmax) {
+	    	double tzminTmp = tzmin;
+	    	tzmin = tzminTmp;
+	    	tzmax = tzminTmp;
+	    } 
+	 
+	    if ((tmin > tzmax) || (tzmin > tmax)) 
+	        return null; 
+	 
+	    if (tzmin > tmin) 
+	        tmin = tzmin; 
+	 
+	    if (tzmax < tmax) 
+	        tmax = tzmax; 
+	    
+	    Vector3d ray1 = new Vector3d();
+	    ray1.x = ray.x;
+	    ray1.y = ray.y;
+	    ray1.z = ray.z;
+	    double t = 0;
+	    if(tmin!=0) t=tmin;
+	    if(tmax!=0) t=tmax;
+	    ray1.scale(t);
+	    return ray1; 
+	} 
+	
 
 	@Override
 	public int getSortingIndex()

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -16,7 +16,6 @@ import net.minecraft.util.math.BlockPos;
 import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;
 
-import java.lang.reflect.Field;
 import java.util.List;
 
 public class BedrockComponentMotionCollision extends BedrockComponentBase implements IComponentParticleUpdate
@@ -31,10 +30,12 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 	public float splitParticleSpeedThreshold; //threshold to activate the split
 	public float radius = 0.01F;
 	public boolean expireOnImpact;
+	public int expirationDelay;
 	public boolean realisticCollision;
-	
-	
 
+	
+	
+	
 	/* Runtime options */
 	public boolean json;
 	private Vector3d previous = new Vector3d();
@@ -58,6 +59,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 		if (element.has("split_particle_speedThreshold")) this.splitParticleSpeedThreshold = element.get("split_particle_speedThreshold").getAsFloat();
 		if (element.has("collision_radius")) this.radius = element.get("collision_radius").getAsFloat();
 		if (element.has("expire_on_contact")) this.expireOnImpact = element.get("expire_on_contact").getAsBoolean();
+		if (element.has("expirationDelay")) this.expirationDelay = element.get("expirationDelay").getAsInt();
 		if (element.has("realisticCollision")) this.realisticCollision = element.get("realisticCollision").getAsBoolean();
 		
 		return super.fromJson(element, parser);
@@ -84,7 +86,8 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 		if (this.splitParticleSpeedThreshold != 0) object.addProperty("split_particle_speedThreshold", this.splitParticleSpeedThreshold);
 		if (this.radius != 0.01F) object.addProperty("collision_radius", this.radius);
 		if (this.expireOnImpact) object.addProperty("expire_on_contact", true);
-
+		if (this.expirationDelay!=0) object.addProperty("expirationDelay", this.expirationDelay);
+		
 		return object;
 	}
 
@@ -151,9 +154,17 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			{
 				if (this.expireOnImpact)
 				{
-					particle.dead = true;
+					if(this.expirationDelay!=0 && particle.expireAge==0)
+					{
+						particle.expireAge = particle.age+this.expirationDelay;
+					}
+					else 
+					{
+						particle.dead = true;
 
-					return;
+						return;
+					}
+					
 				}
 
 				if (particle.relativePosition)

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -17,6 +17,7 @@ import mchorse.mclib.utils.MathUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 
 import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;
@@ -163,7 +164,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			x = (double) offsetData[1];
 			y = (double) offsetData[2];
 			z = (double) offsetData[3];
-			
+			//NOT FINISHED
 			if(entityCollision && d0 == y && origX == x && origZ == z && entities.size()!=0) {
 				
 				for(Entity entity : entities) 
@@ -172,20 +173,47 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 					Vector3f speedEntity = new Vector3f((float)(entity.posX-entity.prevPosX), (float)(entity.posY-entity.prevPosY), (float)(entity.posZ-entity.prevPosZ));
 					
 					Vector3f speedParticle = particle.speed;
-					if(speedEntity.x==0 && speedEntity.y==0 && speedEntity.z==0) speedParticle.scale(1);
+					//if(speedEntity.x==0 && speedEntity.y==0 && speedEntity.z==0) speedParticle.scale(1);
 					Vector3f ray = speedParticle;
 					if(speedEntity.x!=0 || speedEntity.y!=0 || speedEntity.z!=0) {
 						ray = speedEntity;
 					}
-					
 					Vector3d frac = intersect(ray, particle.getGlobalPosition(emitter), entityAABB);
-					
+
 					if(frac!=null) {
 						//don't set the position directly to the intersection point so the normal collision code can start
-						frac.scale(0.8);
+						frac.scale(1);
 						particle.position.add(frac);
-						
-						Vector3d prevPos = new Vector3d(particle.position);
+						Vector3d curPos = particle.getGlobalPosition(emitter);
+						Vector3d prevPos = new Vector3d();
+						prevPos.x = curPos.x-speedParticle.x;
+						prevPos.y = curPos.y-speedParticle.y;
+						prevPos.z = curPos.z-speedParticle.z;
+						AxisAlignedBB particleAABB = new AxisAlignedBB(prevPos.x - r, prevPos.y - r, prevPos.z - r, prevPos.x + r, prevPos.y + r, prevPos.z + r);
+						double origX2 = curPos.x-prevPos.x;
+						double origY2 = curPos.y-prevPos.y;
+						double origZ2 = curPos.z-prevPos.z;
+						Object[] offsetData2 = calculateOffsets(particleAABB, entityAABBs, origX2, origY2, origZ2);
+						particleAABB = (AxisAlignedBB) offsetData2[0];
+						double x2 = (double) offsetData2[1];
+						double y2 = (double) offsetData2[2];
+						double z2 = (double) offsetData2[3];
+						//System.out.println(origX2+" "+x2);
+						//if(entityAABB.intersects(particleAABB)) 
+						//{
+							if (origX2 != x2)
+							{
+								try {
+									collisionHandler(particle, emitter, 'x', origX2, x2, now, prev, entities);
+								} catch (NoSuchFieldException | SecurityException | IllegalArgumentException
+										| IllegalAccessException e) {
+									e.printStackTrace();
+								}
+								particle.position.x += origX2 < r ? r : -r;
+							}
+						//}
+						//this seems to NOT WORK
+						/*Vector3d prevPos = new Vector3d(particle.position);
 						prevPos.add(frac);
 						this.previous.set(particle.getGlobalPosition(emitter, prevPos));
 						this.current.set(particle.getGlobalPosition(emitter));
@@ -203,7 +231,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						aabb = (AxisAlignedBB) offsetData[0];
 						x = (double) offsetData[1];
 						y = (double) offsetData[2];
-						z = (double) offsetData[3];
+						z = (double) offsetData[3];*/
 					}
 				}
 			}
@@ -340,7 +368,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				particle.speed = damping(particle.speed);
 			}
 		}
-		if(this.momentum && this.entityCollision) { //NOT FINISHED
+		if(this.momentum && this.entityCollision) {
 			for(Entity entity : entities) 
 			{
 				particle.speed.x += 2*(entity.posX-entity.prevPosX);
@@ -380,6 +408,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			splitParticle.dragFactor = particle.dragFactor;
 			splitParticle.collisionTexture = particle.collisionTexture;
 			splitParticle.collisionTinting = particle.collisionTinting;
+			splitParticle.expirationDelay = particle.expirationDelay;
+			splitParticle.expireAge = particle.expireAge;
+			splitParticle.firstCollision = particle.firstCollision;
 			
 			splitParticle.age = particle.age;
 			

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -12,7 +12,6 @@ import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
 import mchorse.mclib.math.Operation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import scala.collection.parallel.immutable.ParVector;
 
 import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -190,8 +190,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						{
 							splitParticle(particle, emitter, 'y', d0, y, now, prev);
 						}
+						
 						/*damping*/
-						else if(damp!=0) 
+						if(damp!=0) 
 						{
 							particle.speed = damping(particle.speed);
 						}
@@ -228,8 +229,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						{
 							splitParticle(particle, emitter, 'x', origX, x, now, prev);
 						}
+						
 						/*damping*/
-						else if(damp!=0) 
+						if(damp!=0) 
 						{
 							particle.speed = damping(particle.speed);
 						}
@@ -265,8 +267,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						{
 							splitParticle(particle, emitter, 'z', origZ, z, now, prev);
 						}
+						
 						/*damping*/
-						else if(damp!=0) 
+						if(damp!=0) 
 						{
 							particle.speed = damping(particle.speed);
 						}

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import mchorse.blockbuster.client.particles.components.BedrockComponentBase;
 import mchorse.blockbuster.client.particles.components.IComponentParticleUpdate;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionTinting;
 import mchorse.blockbuster.client.particles.emitter.BedrockEmitter;
 import mchorse.blockbuster.client.particles.emitter.BedrockParticle;
 import mchorse.blockbuster.client.particles.molang.MolangException;
@@ -152,7 +154,10 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 
 			if (d0 != y || origX != x || origZ != z)
 			{
-				if(true) { //later there will be an option to enable texture on collision...
+				if(MolangExpression.isOne(emitter.scheme.getOrCreate(BedrockComponentCollisionTinting.class).enabled)) {
+					particle.collisionTinting = true;
+				}
+				if(MolangExpression.isOne(emitter.scheme.getOrCreate(BedrockComponentCollisionAppearance.class).enabled)) {
 					particle.collisionTexture = true;
 				}
 				if (this.expireOnImpact)

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -201,7 +201,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						if(d0 < y) now.y = aabb.minY;
 						else now.y = aabb.maxY;
 						now.y += d0 < y ? r : -r;
-						collisionHandler(particle, emitter, 'y', now, prev, entities);
+						collisionHandler(particle, emitter, 'y', now, prev);
 					}
 					
 					if (origX != x)
@@ -210,7 +210,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						else now.x = aabb.maxX;
 						now.x += origX < x ? r : -r;
 					
-						collisionHandler(particle, emitter, 'x', now, prev, entities);
+						collisionHandler(particle, emitter, 'x', now, prev);
 					}
 
 					if (origZ != z)
@@ -219,7 +219,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						else now.z = aabb.maxZ;
 						now.z += origZ < z ? r : -r;
 					
-						collisionHandler(particle, emitter, 'z', now, prev, entities);
+						collisionHandler(particle, emitter, 'z', now, prev);
 					}
 				} catch (NoSuchFieldException | SecurityException | IllegalArgumentException
 						| IllegalAccessException e) 
@@ -259,9 +259,11 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 							float tmpTime = particle.collisionTime.x; //collisionTime should be not changed - otherwise the particles will stop when moving against moving entites
 							double delta = particle.position.x-entity.posX;
 							particle.position.x += delta>0 ? r : -r;
-							collisionHandler(particle, emitter, 'x', particle.position, prev, entities);
-							particle.collisionTime.x = tmpTime;
+							collisionHandler(particle, emitter, 'x', particle.position, prev);
 							
+							//collisionTime should not change or otherwise particles will lose their speed although they should be reflected
+							particle.collisionTime.x = tmpTime; 
+
 							//particle speed is always switched (realistcCollision==true), as it always collides with the entity, but it should only have one correct direction
 							if(particle.speed.x>0) {
 								if(speedEntity.x<0) particle.speed.x = -particle.speed.x;
@@ -277,7 +279,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 							float tmpTime = particle.collisionTime.y;
 							double delta = particle.position.y-entity.posY;
 							particle.position.y += delta>0 ? r : -r;
-							collisionHandler(particle, emitter, 'y', particle.position, prev, entities);
+							collisionHandler(particle, emitter, 'y', particle.position, prev);
+							
+							particle.collisionTime.y = tmpTime;
 							
 							if(particle.speed.y>0) {
 								if(speedEntity.y<0) particle.speed.y = -particle.speed.y;
@@ -290,9 +294,12 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						
 						if((aabb2.minZ<entityAABB.maxZ && aabb2.maxZ>entityAABB.maxZ) || (aabb2.maxZ>entityAABB.minZ && aabb2.minZ<entityAABB.minZ))
 						{
+							float tmpTime = particle.collisionTime.y;
 							double delta = particle.position.z-entity.posZ;
 							particle.position.z += delta>0 ? r : -r;
-							collisionHandler(particle, emitter, 'z', particle.position, prev, entities);
+							collisionHandler(particle, emitter, 'z', particle.position, prev);
+							
+							particle.collisionTime.z = tmpTime;
 							
 							if(particle.speed.z>0) {
 								if(speedEntity.z<0) particle.speed.z = -particle.speed.z;
@@ -343,7 +350,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 	}
 	
 	//with java reflect - code redundancy can be avoided quick and easily - may cost a little more performance?
-	public void collisionHandler(BedrockParticle particle, BedrockEmitter emitter, char component, Vector3d now, Vector3d prev, List<Entity> entities) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException
+	public void collisionHandler(BedrockParticle particle, BedrockEmitter emitter, char component, Vector3d now, Vector3d prev) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException
 	{
 		if(!(component=='x' || component=='y' || component=='z')) 
 			throw new IllegalArgumentException("Illegal value of the component: "+component);

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -152,13 +152,16 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 
 			if (d0 != y || origX != x || origZ != z)
 			{
+				if(true) { //later there will be an option to enable texture on collision...
+					particle.collisionTexture = true;
+				}
 				if (this.expireOnImpact)
 				{
 					if(this.expirationDelay!=0 && particle.expireAge==0)
 					{
 						particle.expireAge = particle.age+this.expirationDelay;
 					}
-					else 
+					else if(this.expirationDelay==0)
 					{
 						particle.dead = true;
 

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -23,6 +23,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 	public float bounciness = 1;
 	public float radius = 0.01F;
 	public boolean expireOnImpact;
+	public boolean realisticCollision;
 
 	/* Runtime options */
 	public boolean json;
@@ -42,7 +43,8 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 		if (element.has("coefficient_of_restitution")) this.bounciness = element.get("coefficient_of_restitution").getAsFloat();
 		if (element.has("collision_radius")) this.radius = element.get("collision_radius").getAsFloat();
 		if (element.has("expire_on_contact")) this.expireOnImpact = element.get("expire_on_contact").getAsBoolean();
-
+		if (element.has("realisticCollision")) this.realisticCollision = element.get("realisticCollision").getAsBoolean();
+		
 		return super.fromJson(element, parser);
 	}
 
@@ -57,6 +59,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 		}
 
 		if (!MolangExpression.isOne(this.enabled)) object.add("enabled", this.enabled.toJson());
+		if (this.realisticCollision) object.addProperty("realisticCollision", true);
 		if (this.collissionDrag != 0) object.addProperty("collision_drag", this.collissionDrag);
 		if (this.bounciness != 1) object.addProperty("coefficient_of_restitution", this.bounciness);
 		if (this.radius != 0.01F) object.addProperty("collision_radius", this.radius);
@@ -143,19 +146,22 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 
 				if (d0 != y)
 				{
-					particle.accelerationFactor.y *= -this.bounciness;
+					if(realisticCollision) particle.speed.y = -particle.speed.y*this.bounciness;
+					else particle.accelerationFactor.y *= -this.bounciness;
 					now.y += d0 < y ? r : -r;
 				}
 
 				if (origX != x)
 				{
-					particle.accelerationFactor.x *= -this.bounciness;
+					if(realisticCollision) particle.speed.x = -particle.speed.x*this.bounciness;
+					else particle.accelerationFactor.x *= -this.bounciness;
 					now.x += origX < x ? r : -r;
 				}
 
 				if (origZ != z)
 				{
-					particle.accelerationFactor.z *= -this.bounciness;
+					if(realisticCollision) particle.speed.z = -particle.speed.z*this.bounciness;
+					else particle.accelerationFactor.z *= -this.bounciness;
 					now.z += origZ < z ? r : -r;
 				}
 

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -153,7 +153,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				{
 					if(realisticCollision && this.bounciness!=0) {
 						particle.speed.y = -particle.speed.y*this.bounciness;
-						if(this.randomBounciness!=0 && ((int)particle.speed.y)!=0) {
+						if(this.randomBounciness!=0 && Math.round(particle.speed.y)!=0) {
 							randomBounciness(particle.speed, 'y');
 						}
 					}
@@ -165,7 +165,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				{
 					if(realisticCollision && this.bounciness!=0) {
 						particle.speed.x = -particle.speed.x*this.bounciness;
-						if(this.randomBounciness!=0 && ((int)particle.speed.x)!=0) {
+						if(this.randomBounciness!=0 && Math.round(particle.speed.x)!=0) {
 							randomBounciness(particle.speed, 'x');
 						}
 					}
@@ -177,7 +177,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				{
 					if(realisticCollision && this.bounciness!=0) {
 						particle.speed.z = -particle.speed.z*this.bounciness;
-						if(this.randomBounciness!=0 && ((int)particle.speed.z)!=0) {
+						if(this.randomBounciness!=0 && Math.round(particle.speed.z)!=0) {
 							randomBounciness(particle.speed, 'z');
 						}
 					}
@@ -186,7 +186,8 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				}
 
 				particle.position.set(now);
-				particle.dragFactor += this.collissionDrag;
+				//only apply drag when speed is almost not zero and randombounciness is off...prevent particles from accelerating away
+				if(!(this.randomBounciness!=0 && particle.speed.length()<=0.55)) particle.dragFactor += this.collissionDrag;
 			}
 		}
 	}

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -180,15 +180,18 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 			{
 				if(MolangExpression.isOne(emitter.scheme.getOrCreate(BedrockComponentCollisionTinting.class).enabled)) {
 					particle.collisionTinting = true;
+					particle.firstCollision = particle.age;
 				}
 				if(MolangExpression.isOne(emitter.scheme.getOrCreate(BedrockComponentCollisionAppearance.class).enabled)) {
 					particle.collisionTexture = true;
+					particle.firstCollision = particle.age;
 				}
 				if (this.expireOnImpact)
 				{
 					if(this.expirationDelay!=0 && particle.expireAge==0)
 					{
 						particle.expireAge = particle.age+this.expirationDelay;
+						particle.expirationDelay = this.expirationDelay;
 					}
 					else if(this.expirationDelay==0)
 					{

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -12,6 +12,7 @@ import mchorse.blockbuster.client.particles.molang.expressions.MolangExpression;
 import mchorse.mclib.math.Operation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import scala.collection.parallel.immutable.ParVector;
 
 import javax.vecmath.Vector3d;
 import javax.vecmath.Vector3f;
@@ -159,12 +160,12 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				
 				if (d0 != y)
 				{
-					if(realisticCollision && this.bounciness!=0) {
+					if(realisticCollision) {
 						if(particle.collisionTime.y!=(particle.age-1)) 
 						{
-							particle.speed.y = -particle.speed.y*this.bounciness;
+							if(this.bounciness!=0) particle.speed.y = -particle.speed.y*this.bounciness;
 						}
-						else particle.speed.y = 0;
+						else if(particle.collisionTime.y==(particle.age-1)) particle.speed.y = 0;
 					}
 					else particle.accelerationFactor.y *= -this.bounciness;
 					
@@ -185,12 +186,12 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				
 				if (origX != x)
 				{
-					if(realisticCollision && this.bounciness!=0) {
+					if(realisticCollision) {
 						if(particle.collisionTime.x!=(particle.age-1)) 
 						{
-							particle.speed.x = -particle.speed.x*this.bounciness;
+							if(this.bounciness!=0) particle.speed.x = -particle.speed.x*this.bounciness;
 						}
-						else particle.speed.x = 0;
+						else if(particle.collisionTime.x==(particle.age-1)) particle.speed.x = 0;
 					}
 					else particle.accelerationFactor.x *= -this.bounciness;
 					
@@ -211,12 +212,12 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 
 				if (origZ != z)
 				{
-					if(realisticCollision && this.bounciness!=0) {
+					if(realisticCollision) {
 						if(particle.collisionTime.z!=(particle.age-1)) 
 						{
-							particle.speed.z = -particle.speed.z*this.bounciness;
+							if(this.bounciness!=0) particle.speed.z = -particle.speed.z*this.bounciness;
 						}
-						else particle.speed.z = 0;
+						else if(particle.collisionTime.z==(particle.age-1)) particle.speed.z = 0;
 					}
 					else particle.accelerationFactor.z *= -this.bounciness;
 					

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -164,10 +164,11 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						{
 							particle.speed.y = -particle.speed.y*this.bounciness;
 						}
+						else particle.speed.y = 0;
 					}
 					else particle.accelerationFactor.y *= -this.bounciness;
 					
-					if(this.randomBounciness!=0 && Math.round(particle.speed.y)!=0) {
+					if(this.randomBounciness!=0 /*&& Math.round(particle.speed.y)!=0*/) {
 						if(particle.collisionTime.y!=(particle.age-1))
 						{
 							particle.speed = randomBounciness(particle.speed, 'y', this.randomBounciness);
@@ -189,10 +190,11 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						{
 							particle.speed.x = -particle.speed.x*this.bounciness;
 						}
+						else particle.speed.x = 0;
 					}
 					else particle.accelerationFactor.x *= -this.bounciness;
 					
-					if(this.randomBounciness!=0 && Math.round(particle.speed.x)!=0) {
+					if(this.randomBounciness!=0 /*&& Math.round(particle.speed.x)!=0*/) {
 						if(particle.collisionTime.x!=(particle.age-1))
 						{
 							particle.speed = randomBounciness(particle.speed, 'x', this.randomBounciness);
@@ -214,10 +216,11 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						{
 							particle.speed.z = -particle.speed.z*this.bounciness;
 						}
+						else particle.speed.z = 0;
 					}
 					else particle.accelerationFactor.z *= -this.bounciness;
 					
-					if(this.randomBounciness!=0 && Math.round(particle.speed.z)!=0) {
+					if(this.randomBounciness!=0 /*&& Math.round(particle.speed.z)!=0*/) {
 						if(particle.collisionTime.z!=(particle.age-1))
 						{
 							particle.speed = randomBounciness(particle.speed, 'z', this.randomBounciness);
@@ -258,10 +261,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				splitParticle.drag = particle.drag;
 				splitParticle.dragFactor = particle.dragFactor;
 				
-				Vector3f randomSpeed = randomBounciness(particle.speed, component, (this.randomBounciness!=0) ? this.randomBounciness : 100);
-				splitParticle.speed.x = randomSpeed.x/this.splitParticleCount;
-				splitParticle.speed.y = randomSpeed.y/this.splitParticleCount;
-				splitParticle.speed.z = randomSpeed.z/this.splitParticleCount;
+				
 				splitParticle.age = particle.age;
 				
 				switch(component) 
@@ -285,6 +285,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						splitParticle.position.z += orig < offset ? this.radius : -this.radius;
 						break;
 				}
+				Vector3f randomSpeed = randomBounciness(particle.speed, component, (this.randomBounciness!=0) ? this.randomBounciness : 100);
+				randomSpeed.scale(1.0f/this.splitParticleCount);
+				splitParticle.speed.set(randomSpeed);
 				emitter.splitParticles.add(splitParticle);
 			}
 			particle.dead = true;

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -215,6 +215,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 							| IllegalAccessException e) {
 						e.printStackTrace();
 					}
+					
+					if(d0 < y) now.y = aabb.minY;
+					else now.y = aabb.maxY;
 					now.y += d0 < y ? r : -r;
 				}
 				
@@ -226,6 +229,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 							| IllegalAccessException e) {
 						e.printStackTrace();
 					}
+					
+					if(origX < x) now.x = aabb.minX;
+					else now.x = aabb.maxX;
 					now.x += origX < x ? r : -r;
 				}
 
@@ -237,6 +243,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 							| IllegalAccessException e) {
 						e.printStackTrace();
 					}
+					
+					if(origZ < z) now.z = aabb.minZ;
+					else now.z = aabb.maxZ;
 					now.z += origZ < z ? r : -r;
 				}
 

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -151,9 +151,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 				
 				if (d0 != y)
 				{
-					if(realisticCollision) {
+					if(realisticCollision && this.bounciness!=0) {
 						particle.speed.y = -particle.speed.y*this.bounciness;
-						if(this.randomBounciness!=0) {
+						if(this.randomBounciness!=0 && ((int)particle.speed.y)!=0) {
 							randomBounciness(particle.speed, 'y');
 						}
 					}
@@ -163,9 +163,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 
 				if (origX != x)
 				{
-					if(realisticCollision) {
+					if(realisticCollision && this.bounciness!=0) {
 						particle.speed.x = -particle.speed.x*this.bounciness;
-						if(this.randomBounciness!=0) {
+						if(this.randomBounciness!=0 && ((int)particle.speed.x)!=0) {
 							randomBounciness(particle.speed, 'x');
 						}
 					}
@@ -175,9 +175,9 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 
 				if (origZ != z)
 				{
-					if(realisticCollision) {
+					if(realisticCollision && this.bounciness!=0) {
 						particle.speed.z = -particle.speed.z*this.bounciness;
-						if(this.randomBounciness!=0) {
+						if(this.randomBounciness!=0 && ((int)particle.speed.z)!=0) {
 							randomBounciness(particle.speed, 'z');
 						}
 					}
@@ -204,14 +204,17 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 					vector.x += vector.x<0 ? -random1 : random1;
 					vector.y += random2;
 					vector.z += random3;
+					break;
 				case 'y':
 					vector.y += vector.y<0 ? -random1 : random1;
 					vector.x += random2;
 					vector.z += random3;
+					break;
 				case 'z':
 					vector.z += vector.z<0 ? -random1 : random1;
 					vector.y += random2;
 					vector.x += random3;
+					break;
 			}
 			vector.scale(prevSpeedLength/vector.length()); //scale back to original length
 		}

--- a/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/components/motion/BedrockComponentMotionCollision.java
@@ -294,7 +294,7 @@ public class BedrockComponentMotionCollision extends BedrockComponentBase implem
 						
 						if((aabb2.minZ<entityAABB.maxZ && aabb2.maxZ>entityAABB.maxZ) || (aabb2.maxZ>entityAABB.minZ && aabb2.minZ<entityAABB.minZ))
 						{
-							float tmpTime = particle.collisionTime.y;
+							float tmpTime = particle.collisionTime.z;
 							double delta = particle.position.z-entity.posZ;
 							particle.position.z += delta>0 ? r : -r;
 							collisionHandler(particle, emitter, 'z', particle.position, prev);

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -7,6 +7,7 @@ import mchorse.blockbuster.client.particles.components.IComponentEmitterUpdate;
 import mchorse.blockbuster.client.particles.components.IComponentParticleInitialize;
 import mchorse.blockbuster.client.particles.components.IComponentParticleRender;
 import mchorse.blockbuster.client.particles.components.IComponentParticleUpdate;
+import mchorse.blockbuster.client.particles.components.appearance.BedrockComponentCollisionAppearance;
 import mchorse.blockbuster.client.textures.GifTexture;
 import mchorse.mclib.math.IValue;
 import mchorse.mclib.math.Variable;
@@ -449,21 +450,26 @@ public class BedrockEmitter
 				});
 			}
 
-			GifTexture.bindTexture(this.scheme.texture, this.age, partialTicks);
-			builder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_LMAP_COLOR);
-
+			
 			for (BedrockParticle particle : this.particles)
 			{
+				if(!particle.collisionTexture) GifTexture.bindTexture(this.scheme.texture, this.age, partialTicks);
+				else GifTexture.bindTexture(this.scheme.get(BedrockComponentCollisionAppearance.class).texture, this.age, partialTicks);
+				
+				builder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_LMAP_COLOR);
 				this.setEmitterVariables(partialTicks);
 				this.setParticleVariables(particle, partialTicks);
 
 				for (IComponentParticleRender component : renders)
 				{
-					component.render(this, particle, builder, partialTicks);
+					if(!(particle.collisionTexture && component.getClass().getName().contains("BedrockComponentAppearanceBillboard")))
+					{
+						component.render(this, particle, builder, partialTicks);
+					}	
 				}
+				Tessellator.getInstance().draw();
 			}
 
-			Tessellator.getInstance().draw();
 		}
 
 		for (IComponentParticleRender component : renders)

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -453,6 +453,8 @@ public class BedrockEmitter
 			
 			for (BedrockParticle particle : this.particles)
 			{
+				//another possible implementation, without rendering for each iteration of the loop, would be to create a list of particles
+				//with collisionTexture on and one with particles without collisionTexture and render them with two loops...
 				if(!particle.collisionTexture) GifTexture.bindTexture(this.scheme.texture, this.age, partialTicks);
 				
 				builder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_LMAP_COLOR);

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -291,11 +291,11 @@ public class BedrockEmitter
 		}
 		if(!this.splitParticles.isEmpty()) 
 		{
-			ListIterator<BedrockParticle> it1 = this.splitParticles.listIterator();
+			Iterator<BedrockParticle> it1 = this.splitParticles.iterator();
 			while (it1.hasNext())
 			{
 				BedrockParticle splitParticle = it1.next();
-				it.add(splitParticle);
+				this.particles.add(splitParticle);
 				it1.remove();
 			}
 		}

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -89,6 +89,10 @@ public class BedrockEmitter
 	private Variable varEmitterRandom2;
 	private Variable varEmitterRandom3;
 	private Variable varEmitterRandom4;
+	private Variable varSpeedABS;
+	private Variable varSpeedX;
+	private Variable varSpeedY;
+	private Variable varSpeedZ;
 
 	public boolean isFinished()
 	{
@@ -149,6 +153,10 @@ public class BedrockEmitter
 	public void setupVariables()
 	{
 		this.varAge = this.scheme.parser.variables.get("variable.particle_age");
+		this.varSpeedABS = this.scheme.parser.variables.get("variable.particle_speed.length");
+		this.varSpeedX = this.scheme.parser.variables.get("variable.particle_speed.x");
+		this.varSpeedY = this.scheme.parser.variables.get("variable.particle_speed.y");
+		this.varSpeedZ = this.scheme.parser.variables.get("variable.particle_speed.z");
 		this.varLifetime = this.scheme.parser.variables.get("variable.particle_lifetime");
 		this.varRandom1 = this.scheme.parser.variables.get("variable.particle_random_1");
 		this.varRandom2 = this.scheme.parser.variables.get("variable.particle_random_2");
@@ -165,6 +173,10 @@ public class BedrockEmitter
 
 	public void setParticleVariables(BedrockParticle particle, float partialTicks)
 	{
+		if (this.varSpeedABS != null) this.varSpeedABS.set(particle.speed.length());
+		if (this.varSpeedX != null) this.varSpeedX.set(particle.speed.x);
+		if (this.varSpeedY != null) this.varSpeedY.set(particle.speed.y);
+		if (this.varSpeedZ != null) this.varSpeedZ.set(particle.speed.z);
 		if (this.varAge != null) this.varAge.set(particle.getAge(partialTicks));
 		if (this.varLifetime != null) this.varLifetime.set(particle.lifetime / 20.0);
 		if (this.varRandom1 != null) this.varRandom1.set(particle.random1);

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -29,12 +29,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 public class BedrockEmitter
 {
 	public BedrockScheme scheme;
 	public List<BedrockParticle> particles = new ArrayList<BedrockParticle>();
+	public List<BedrockParticle> splitParticles = new ArrayList<BedrockParticle>();
 	public Map<String, IValue> variables;
 
 	public EntityLivingBase target;
@@ -274,17 +276,27 @@ public class BedrockEmitter
 	 */
 	private void updateParticles()
 	{
-		Iterator<BedrockParticle> it = this.particles.iterator();
+		ListIterator<BedrockParticle> it = this.particles.listIterator();
 
 		while (it.hasNext())
 		{
 			BedrockParticle particle = it.next();
 
 			this.updateParticle(particle);
-
+			
 			if (particle.dead)
 			{
 				it.remove();
+			}
+		}
+		if(!this.splitParticles.isEmpty()) 
+		{
+			ListIterator<BedrockParticle> it1 = this.splitParticles.listIterator();
+			while (it1.hasNext())
+			{
+				BedrockParticle splitParticle = it1.next();
+				it.add(splitParticle);
+				it1.remove();
 			}
 		}
 	}
@@ -320,7 +332,7 @@ public class BedrockEmitter
 	/**
 	 * Create a new particle
 	 */
-	private BedrockParticle createParticle(boolean forceRelative)
+	public BedrockParticle createParticle(boolean forceRelative)
 	{
 		BedrockParticle particle = new BedrockParticle();
 

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -454,7 +454,6 @@ public class BedrockEmitter
 			for (BedrockParticle particle : this.particles)
 			{
 				if(!particle.collisionTexture) GifTexture.bindTexture(this.scheme.texture, this.age, partialTicks);
-				else GifTexture.bindTexture(this.scheme.get(BedrockComponentCollisionAppearance.class).texture, this.age, partialTicks);
 				
 				builder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_LMAP_COLOR);
 				this.setEmitterVariables(partialTicks);
@@ -462,7 +461,7 @@ public class BedrockEmitter
 
 				for (IComponentParticleRender component : renders)
 				{
-					if(!(particle.collisionTexture && component.getClass().getName().contains("BedrockComponentAppearanceBillboard")))
+					if(!((particle.collisionTexture || particle.collisionTinting) && component.getClass().getName().contains("BedrockComponentAppearanceBillboard")))
 					{
 						component.render(this, particle, builder, partialTicks);
 					}	

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockEmitter.java
@@ -461,6 +461,11 @@ public class BedrockEmitter
 
 				for (IComponentParticleRender component : renders)
 				{
+					/*
+					 * if collisionTexture or collisionTinting is true - means that those options are enabled
+					 * therefore the old Billboardappearance should not be called
+					 * because collisionAppearance.class is rendering
+					 */
 					if(!((particle.collisionTexture || particle.collisionTinting) && component.getClass().getName().contains("BedrockComponentAppearanceBillboard")))
 					{
 						component.render(this, particle, builder, partialTicks);

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -17,6 +17,7 @@ public class BedrockParticle
 	/* States */
 	public int age;
 	public int lifetime;
+	public int expireAge; //age when the particle should expire
 	public boolean dead;
 	public boolean relativePosition;
 	public boolean relativeRotation;
@@ -165,7 +166,8 @@ public class BedrockParticle
 			this.position.z += vec.z / 20F;
 		}
 
-		if (this.lifetime >= 0 && this.age >= this.lifetime)
+		if (this.lifetime >= 0 &&
+			(this.age >= this.lifetime || (this.age>=this.expireAge && this.expireAge!=0)) )
 		{
 			this.dead = true;
 		}

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -18,6 +18,7 @@ public class BedrockParticle
 	public int age;
 	public int lifetime;
 	public int expireAge; //age when the particle should expire
+	public int expirationDelay; //used to determine lifetime when expirationDelay is on
 	public boolean dead;
 	public boolean relativePosition;
 	public boolean relativeRotation;
@@ -28,17 +29,15 @@ public class BedrockParticle
 	
 	/*
 	 * this is used to estimate whether an object is only bouncing or lying on a surface
-	 * 
-	 * NOTE: rarely doesn't work - specifically with realistic collision.
-	 * I haven't found a solution, to stop the particles from rarely 
-	 * bouncing slightly, without changing the whole calculation...
+	 *
 	 * CollisionTime won't work when e.g. the particle bounces of the surface and directly in the next
-	 * update cycle hits the same surface side like from top of the block to bottom of the block...
+	 * update cycle hits the same surface side, like from top of the block to bottom of the block...
 	 * I think this probably never happens in practice
 	 */
 	public Vector3f collisionTime = new Vector3f(-2f, -2f,-2f);
 	public boolean collisionTexture;
 	public boolean collisionTinting;
+	public int firstCollision = -1; //for collision Appearance needed for animation
 	
 	/* Rotation */
 	public float rotation;

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -162,7 +162,7 @@ public class BedrockParticle
 			{
 				this.matrix.transform(vec);
 			}
-
+			
 			this.position.x += vec.x / 20F;
 			this.position.y += vec.y / 20F;
 			this.position.z += vec.z / 20F;

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -37,7 +37,8 @@ public class BedrockParticle
 	 * I think this probably never happens in practice
 	 */
 	public Vector3f collisionTime = new Vector3f(-2f, -2f,-2f);
-
+	public boolean collisionTexture;
+	
 	/* Rotation */
 	public float rotation;
 	public float initialRotation;

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -175,7 +175,6 @@ public class BedrockParticle
 		}
 
 		this.age ++;
-		System.out.println(this.speed.length());
 	}
 
 	public void setupMatrix(BedrockEmitter emitter)

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -20,6 +20,9 @@ public class BedrockParticle
 	public boolean dead;
 	public boolean relativePosition;
 	public boolean relativeRotation;
+	public boolean relativeDirection;
+	public boolean relativeAcceleration;
+	public boolean gravity; //works best with relativeDirection
 	public boolean manual;
 
 	/* Rotation */
@@ -119,9 +122,18 @@ public class BedrockParticle
 			this.rotation = this.initialRotation + this.rotationVelocity * this.age;
 
 			/* Position */
+			if(this.relativeDirection && this.age==0) {
+				emitter.rotation.transform(this.speed);
+			}
+			if(this.relativeAcceleration) {
+				emitter.rotation.transform(this.acceleration);
+			}
+			
 			Vector3f vec = new Vector3f(this.speed);
 			vec.scale(-(this.drag + this.dragFactor));
-
+			
+			if(this.gravity) this.acceleration.y -= 9.81;
+			
 			this.acceleration.add(vec);
 			this.acceleration.scale(1 / 20F);
 			this.speed.add(this.acceleration);

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -38,6 +38,7 @@ public class BedrockParticle
 	 */
 	public Vector3f collisionTime = new Vector3f(-2f, -2f,-2f);
 	public boolean collisionTexture;
+	public boolean collisionTinting;
 	
 	/* Rotation */
 	public float rotation;
@@ -174,6 +175,7 @@ public class BedrockParticle
 		}
 
 		this.age ++;
+		System.out.println(this.speed.length());
 	}
 
 	public void setupMatrix(BedrockEmitter emitter)

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -28,11 +28,14 @@ public class BedrockParticle
 	/*
 	 * this is used to estimate whether an object is only bouncing or lying on a surface
 	 * 
-	 * NOTE: doesn't always work - specifically sometimes with realistic collision. 
-	 * I haven't found a solution, to stop the particles from sometimes 
+	 * NOTE: rarely doesn't work - specifically with realistic collision.
+	 * I haven't found a solution, to stop the particles from rarely 
 	 * bouncing slightly, without changing the whole calculation...
+	 * CollisionTime won't work when e.g. the particle bounces of the surface and directly in the next
+	 * update cycle hits the same surface side like from top of the block to bottom of the block...
+	 * I think this probably never happens in practice
 	 */
-	public Vector3f collisionTime = new Vector3f();
+	public Vector3f collisionTime = new Vector3f(-2f, -2f,-2f);
 
 	/* Rotation */
 	public float rotation;

--- a/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
+++ b/src/main/java/mchorse/blockbuster/client/particles/emitter/BedrockParticle.java
@@ -24,6 +24,15 @@ public class BedrockParticle
 	public boolean relativeAcceleration;
 	public boolean gravity; //works best with relativeDirection
 	public boolean manual;
+	
+	/*
+	 * this is used to estimate whether an object is only bouncing or lying on a surface
+	 * 
+	 * NOTE: doesn't always work - specifically sometimes with realistic collision. 
+	 * I haven't found a solution, to stop the particles from sometimes 
+	 * bouncing slightly, without changing the whole calculation...
+	 */
+	public Vector3f collisionTime = new Vector3f();
 
 	/* Rotation */
 	public float rotation;


### PR DESCRIPTION
List of additions:
 - local space section:
	- relative direction: it rotates the direction vector when spawning according to the rotation of the emitter/body part. 
	  Example: make particles shoot out of a body part like blood
	- relative acceleration: it rotates the acceleration vector throughout the whole lifetime of a particle according to the body 
	  part's local rotation.
	- gravity: this adds a y acceleration of -9.81 which won't be affected by the local acceleration
- appearance section:
	- camera facing mode button
 - collision section:
	- realistic collision: the direction vector will be mirrored on collision. Example: together with gravity particles can now 
	  bounce realistically like a bouncy rubber ball.
	- random direction: this randomizes the direction on collision. It can be used with realistic collision on or off. It doesn't 
	  affect the speed, it only changes the direction. When bounciness is zero this still changes the direction just without
	  reflecting on the surface. This could be used for force fields.
		- preserve energy: when bounciness=0 and random bounciness!=0 - an enabled preserve energy would ignore that the vector component responsible for colliding will be zero. Enabled preserve energy will make the particles fast.
	- split particles: this splits the particles into a given amount on impact. Their speed will change according to the number of 
	  splits e.g. 4 splits => speed/4
	- split particles speed threshold: this is the speed threshold for activating the split process.
	- damping: reduce the velocity of the particles on impact. Valid range 0 - 1, 1 being the highest damping (1 reduces the 
	  velocity completely)
	- random damping: randomize the damping. Values are 0 - 1. Example: damping of 1.0 and random damping of 0.5 means the damping will vary between 0.5 and 1.5
	- change texture/appearance on collision
	- change tint and lighting on collision
	- expire on impact delay: would be also useful for texture on impact - can be used with Molang Expressions like math.random - negative values will be turned into positive values
	- collision with entity's hitboxes
	- collision with entity pseudo momentum
		- Idea for the future: add multiple hitboxes to models in the model editor
		- Idea for the future: own hitbox so it can be rectangular - then it also needs to rotate
- MolangExpressions
	- added the variables "variable.particle_speed.length",  "variable.particle_speed.x", "variable.particle_speed.y" and "variable.particle_speed.z". Could be used for motionblur like effect.
	- added the variable (later by McHorse) "variable.particle_bounces": it counts how many times a particle bounced off a surface - doesn't count for ever when it's lying on a surface (one count for that situation).

Known bugs:
- _with realistic collision on: sometimes the particle bounces very slightly on the ground although it is clearly lying on the ground._ probably fixed now - fixed original code: particles now reposition correctly with high radius