### PR TITLE
Audio Sync and tracker crash fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ minecraft
     replace "%MCLIB%", project.mclib
     replace "%APERTURE%", project.aperture
     replace "%EMOTICONS%", project.emoticons
+    replace "%MINEMA%", project.minema
 }
 
 dependencies 
@@ -51,6 +52,7 @@ dependencies
 	compile files("run/libs/mclib-${mclib}-${project.minecraft.version}-dev.jar")
 	compile files("run/libs/metamorph-${metamorph}-${project.minecraft.version}-dev.jar")
 	compile files("run/libs/aperture-${aperture}-${project.minecraft.version}-dev.jar")
+    compile files("run/libs/Minema-${minema}-${project.minecraft.version}-dev.jar")
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Blockbuster gradle properties
 version=2.4
-mclib=2.3.6
+mclib=2.3.7
 metamorph=1.2.11
 aperture=1.7
 emoticons=1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ mclib=2.3.6
 metamorph=1.2.11
 aperture=1.7
 emoticons=1.0
+minema=3.6.2
 
 coremodPath=mchorse.blockbuster.core.BBCoreMod
 mc_version=1.12.2

--- a/help/en_US/config.yml
+++ b/help/en_US/config.yml
@@ -87,3 +87,4 @@ blockbuster.config:
         waveform_height: Audio bar height
         waveform_filename: Show audio bar's filename
         waveform_time: Show audio bar's playback time
+        audio_sync: Sync audio between server and client

--- a/help/en_US/config_comments.yml
+++ b/help/en_US/config_comments.yml
@@ -57,3 +57,4 @@ blockbuster.config.comments:
         waveform_height: Height of an audio bar in pixels
         waveform_filename: Whether filename of the played audio in the audio should be shown
         waveform_time: Whether audio track's playback time should be displayed. Keep in mind that audio track's playback time doesn't necessarily represent scene's current playback time!
+        audio_sync: Whether the audio should always try to sync between server and client. This does not affect the playback and syncing when rejoining on a server with running audio. This option is for starting audio playback while being on the server. This configuration is a server side option.

--- a/src/main/java/mchorse/blockbuster/Blockbuster.java
+++ b/src/main/java/mchorse/blockbuster/Blockbuster.java
@@ -194,6 +194,7 @@ public class Blockbuster
     public static ValueInt audioWaveformHeight;
     public static ValueBoolean audioWaveformFilename;
     public static ValueBoolean audioWaveformTime;
+    public static ValueBoolean audioSync;
 
     /**
      * "Macro" for getting resource location for Blockbuster mod items,
@@ -288,13 +289,24 @@ public class Blockbuster
         builder.category("audio").register(new ValueAudioButtons("buttons"));
 
         audioWaveformVisible = builder.getBoolean("waveform_visible", true);
-        audioWaveformDensity = builder.getInt("waveform_density", 20, 10, 100);
-        audioWaveformWidth = builder.getFloat("waveform_width", 0.5F, 0F, 1F);
-        audioWaveformHeight = builder.getInt("waveform_height", 24, 10, 40);
-        audioWaveformFilename = builder.getBoolean("waveform_filename", true);
-        audioWaveformTime = builder.getBoolean("waveform_time", true);
+        audioWaveformVisible.clientSide();
 
-        builder.getCategory().markClientSide();
+        audioWaveformDensity = builder.getInt("waveform_density", 20, 10, 100);
+        audioWaveformDensity.clientSide();
+
+        audioWaveformWidth = builder.getFloat("waveform_width", 0.5F, 0F, 1F);
+        audioWaveformWidth.clientSide();
+
+        audioWaveformHeight = builder.getInt("waveform_height", 24, 10, 40);
+        audioWaveformHeight.clientSide();
+
+        audioWaveformFilename = builder.getBoolean("waveform_filename", true);
+        audioWaveformFilename.clientSide();
+
+        audioWaveformTime = builder.getBoolean("waveform_time", true);
+        audioWaveformTime.clientSide();
+
+        audioSync = builder.getBoolean("audio_sync", true);
     }
 
     @EventHandler

--- a/src/main/java/mchorse/blockbuster/Blockbuster.java
+++ b/src/main/java/mchorse/blockbuster/Blockbuster.java
@@ -69,7 +69,7 @@ import org.apache.logging.log4j.Logger;
  * of custom models)</li>
  * </ul>
  */
-@Mod(modid = Blockbuster.MOD_ID, name = Blockbuster.MODNAME, version = Blockbuster.VERSION, dependencies = "after:aperture@[%APERTURE%,);before:emoticons@[%EMOTICONS%,);required-after:metamorph@[%METAMORPH%,);required-after:mclib@[%MCLIB%,);required-after:forge@[14.23.2.2638,)", updateJSON = "https://raw.githubusercontent.com/mchorse/blockbuster/1.12/version.json")
+@Mod(modid = Blockbuster.MOD_ID, name = Blockbuster.MODNAME, version = Blockbuster.VERSION, dependencies = "after:minema@[%MINEMA%,);before:aperture@[%APERTURE%,);before:emoticons@[%EMOTICONS%,);required-after:metamorph@[%METAMORPH%,);required-after:mclib@[%MCLIB%,);required-after:forge@[14.23.2.2638,)", updateJSON = "https://raw.githubusercontent.com/mchorse/blockbuster/1.12/version.json")
 public class Blockbuster
 {
     /* Mod info */

--- a/src/main/java/mchorse/blockbuster/aperture/CameraHandler.java
+++ b/src/main/java/mchorse/blockbuster/aperture/CameraHandler.java
@@ -3,6 +3,7 @@ package mchorse.blockbuster.aperture;
 import mchorse.aperture.Aperture;
 import mchorse.aperture.ClientProxy;
 import mchorse.aperture.camera.CameraAPI;
+import mchorse.aperture.camera.minema.MinemaIntegration;
 import mchorse.aperture.client.gui.GuiCameraEditor;
 import mchorse.aperture.events.CameraEditorEvent;
 import mchorse.aperture.network.common.PacketCameraProfileList;
@@ -99,6 +100,23 @@ public class CameraHandler
     public static boolean isApertureLoaded()
     {
         return Loader.isModLoaded(Aperture.MOD_ID);
+    }
+
+    /**
+     * Check whether Aperture and Minema is loaded
+     */
+    public static boolean isApertureAndMinemaLoaded()
+    {
+        return isApertureLoaded() && isMinemaAvailable();
+    }
+
+    /**
+     * Check whether Minema is available
+     */
+    @Method(modid = Aperture.MOD_ID)
+    private static boolean isMinemaAvailable()
+    {
+        return MinemaIntegration.isAvailable();
     }
 
     public static void register()

--- a/src/main/java/mchorse/blockbuster/aperture/network/server/ServerHandlerAudioShift.java
+++ b/src/main/java/mchorse/blockbuster/aperture/network/server/ServerHandlerAudioShift.java
@@ -17,7 +17,7 @@ public class ServerHandlerAudioShift extends ServerMessageHandler<PacketAudioShi
         if (scene != null)
         {
             scene.audioShift = message.shift;
-            scene.sendAudioToPlayer(AudioState.SET, scene.getTick());
+            scene.sendAudio(AudioState.SET, scene.getTick());
 
             try
             {

--- a/src/main/java/mchorse/blockbuster/aperture/network/server/ServerHandlerAudioShift.java
+++ b/src/main/java/mchorse/blockbuster/aperture/network/server/ServerHandlerAudioShift.java
@@ -17,7 +17,7 @@ public class ServerHandlerAudioShift extends ServerMessageHandler<PacketAudioShi
         if (scene != null)
         {
             scene.audioShift = message.shift;
-            scene.sendAudio(AudioState.SET, scene.getTick());
+            scene.sendAudioToPlayer(AudioState.SET, scene.getTick());
 
             try
             {

--- a/src/main/java/mchorse/blockbuster/audio/AudioLibrary.java
+++ b/src/main/java/mchorse/blockbuster/audio/AudioLibrary.java
@@ -1,11 +1,13 @@
 package mchorse.blockbuster.audio;
 
 import mchorse.blockbuster.Blockbuster;
+import mchorse.mclib.utils.LatencyTimer;
 import mchorse.mclib.utils.wav.Wave;
 import mchorse.mclib.utils.wav.WavePlayer;
 import mchorse.mclib.utils.wav.WaveReader;
 import mchorse.mclib.utils.wav.Waveform;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -101,13 +103,29 @@ public class AudioLibrary
         return audio;
     }
 
-    public boolean play(String audio, AudioState state, int shift)
+    /**
+     *
+     * @param audio name of the file (without .wav file ending)
+     * @param state
+     * @param shift in ticks
+     * @param delay for syncing purposes, if not used, pass null as value
+     * @return
+     */
+    public boolean play(String audio, AudioState state, int shift, @Nullable LatencyTimer delay)
     {
         AudioFile file = this.files.get(audio);
+
+        float elapsed = 0;
 
         if (file == null || file.canBeUpdated())
         {
             file = this.load(audio, new File(this.folder, audio + ".wav"));
+
+            /* Account for networking and loading delays */
+            if (delay != null)
+            {
+                elapsed = delay.getElapsedTime() / 1000F;
+            }
         }
 
         if (file == null || file.isEmpty())
@@ -117,7 +135,7 @@ public class AudioLibrary
 
         WavePlayer player = file.player;
 
-        float seconds = shift / 20F;
+        float seconds = shift / 20F + elapsed;
 
         if (state == AudioState.REWIND)
         {

--- a/src/main/java/mchorse/blockbuster/audio/AudioLibrary.java
+++ b/src/main/java/mchorse/blockbuster/audio/AudioLibrary.java
@@ -109,7 +109,7 @@ public class AudioLibrary
      * @param state
      * @param shift in ticks
      * @param delay for syncing purposes, if not used, pass null as value
-     * @return
+     * @return false if the file is null or empty
      */
     public boolean play(String audio, AudioState state, int shift, @Nullable LatencyTimer delay)
     {

--- a/src/main/java/mchorse/blockbuster/capabilities/CapabilityHandler.java
+++ b/src/main/java/mchorse/blockbuster/capabilities/CapabilityHandler.java
@@ -14,6 +14,7 @@ import mchorse.blockbuster.recording.RecordUtils;
 import mchorse.blockbuster.recording.scene.Scene;
 import mchorse.blockbuster.recording.scene.SceneLocation;
 import mchorse.blockbuster.utils.EntityUtils;
+import mchorse.mclib.utils.LatencyTimer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -23,6 +24,7 @@ import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.StartTracking;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientConnectedToServerEvent;
 
 import java.util.Map;
 
@@ -76,7 +78,7 @@ public class CapabilityHandler
         for(Map.Entry<String, Scene> entry : CommonProxy.scenes.getScenes().entrySet())
         {
             Scene scene = entry.getValue();
-            scene.sendAudioToPlayer(scene.getAudioState(), 0, player);
+            scene.sendAudioToPlayer(scene.getAudioState(), scene.getTick(), new LatencyTimer(), player);
         }
     }
 

--- a/src/main/java/mchorse/blockbuster/capabilities/CapabilityHandler.java
+++ b/src/main/java/mchorse/blockbuster/capabilities/CapabilityHandler.java
@@ -24,7 +24,6 @@ import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.StartTracking;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
-import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientConnectedToServerEvent;
 
 import java.util.Map;
 

--- a/src/main/java/mchorse/blockbuster/capabilities/CapabilityHandler.java
+++ b/src/main/java/mchorse/blockbuster/capabilities/CapabilityHandler.java
@@ -24,6 +24,8 @@ import net.minecraftforge.event.entity.player.PlayerEvent.StartTracking;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 
+import java.util.Map;
+
 /**
  * Capability handler class
  *
@@ -68,6 +70,13 @@ public class CapabilityHandler
             {
                 Dispatcher.sendTo(new PacketSceneCast(new SceneLocation(scene)).open(false), player);
             }
+        }
+
+        /* send playing audio to client */
+        for(Map.Entry<String, Scene> entry : CommonProxy.scenes.getScenes().entrySet())
+        {
+            Scene scene = entry.getValue();
+            scene.sendAudioToPlayer(scene.getAudioState(), 0, player);
         }
     }
 

--- a/src/main/java/mchorse/blockbuster/network/client/audio/ClientHandlerAudio.java
+++ b/src/main/java/mchorse/blockbuster/network/client/audio/ClientHandlerAudio.java
@@ -13,6 +13,6 @@ public class ClientHandlerAudio extends ClientMessageHandler<PacketAudio>
     @SideOnly(Side.CLIENT)
     public void run(EntityPlayerSP player, PacketAudio message)
     {
-        ClientProxy.audio.play(message.audio, message.state, message.shift);
+        ClientProxy.audio.play(message.audio, message.state, message.shift, message.delay);
     }
 }

--- a/src/main/java/mchorse/blockbuster/recording/scene/Scene.java
+++ b/src/main/java/mchorse/blockbuster/recording/scene/Scene.java
@@ -922,7 +922,7 @@ public class Scene
      * Send the audio in the scene, if present, to all players on the server
      * and set this.audioState to the provided state.
      * @param state
-     * @param shift
+     * @param shift shift the audio in ticks
      */
     public void sendAudio(AudioState state, int shift)
     {
@@ -946,20 +946,27 @@ public class Scene
     /**
      * Send the audio to the provided player
      * @param state
-     * @param shift
-     * @param player
+     * @param shift shift the audio in ticks
+     * @param player the entity player the audio should be sent to
      */
     public void sendAudioToPlayer(AudioState state, int shift, EntityPlayerMP player)
     {
-        this.sendAudioToPlayer(state, shift, null, player);
+        LatencyTimer timer = null;
+
+        if (Blockbuster.audioSync.get())
+        {
+            timer = new LatencyTimer();
+        }
+
+        this.sendAudioToPlayer(state, shift, timer, player);
     }
 
     /**
      * Send the audio to the provided player
      * @param state
-     * @param shift
+     * @param shift shift the audio in ticks
      * @param latencyTimer a timer to measure (approximately) the delay to sync the audio properly
-     * @param player
+     * @param player the entity player the audio should be sent to
      */
     public void sendAudioToPlayer(AudioState state, int shift, LatencyTimer latencyTimer, EntityPlayerMP player)
     {

--- a/src/main/java/mchorse/blockbuster/recording/scene/SceneManager.java
+++ b/src/main/java/mchorse/blockbuster/recording/scene/SceneManager.java
@@ -37,6 +37,11 @@ public class SceneManager
     private Map<String, Scene> toPut = new HashMap<String, Scene>();
     private boolean ticking;
 
+    public Map<String, Scene> getScenes()
+    {
+        return new HashMap<>(this.scenes);
+    }
+
     public static boolean isValidFilename(String filename)
     {
         return !filename.isEmpty() && Patterns.FILENAME.matcher(filename).matches();

--- a/src/main/java/mchorse/blockbuster_pack/trackers/ApertureTracker.java
+++ b/src/main/java/mchorse/blockbuster_pack/trackers/ApertureTracker.java
@@ -1,5 +1,6 @@
 package mchorse.blockbuster_pack.trackers;
 
+import mchorse.aperture.Aperture;
 import mchorse.aperture.camera.CameraExporter;
 import mchorse.aperture.camera.minema.MinemaIntegration;
 import mchorse.aperture.client.gui.GuiMinemaPanel;
@@ -9,7 +10,7 @@ import mchorse.mclib.utils.ReflectionUtils;
 import mchorse.metamorph.api.morphs.AbstractMorph;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Optional;
 
 public class ApertureTracker extends BaseTracker
 {
@@ -18,6 +19,7 @@ public class ApertureTracker extends BaseTracker
     public boolean combineTracking;
 
     @Override
+    @Optional.Method(modid = Aperture.MOD_ID)
     public void track(EntityLivingBase target, double x, double y, double z, float entityYaw, float partialTicks)
     {
         if(!ReflectionUtils.isOptifineShadowPass() && !this.name.equals(""))

--- a/src/main/java/mchorse/blockbuster_pack/trackers/ApertureTracker.java
+++ b/src/main/java/mchorse/blockbuster_pack/trackers/ApertureTracker.java
@@ -3,11 +3,13 @@ package mchorse.blockbuster_pack.trackers;
 import mchorse.aperture.camera.CameraExporter;
 import mchorse.aperture.camera.minema.MinemaIntegration;
 import mchorse.aperture.client.gui.GuiMinemaPanel;
+import mchorse.blockbuster.aperture.CameraHandler;
 import mchorse.blockbuster_pack.morphs.TrackerMorph;
 import mchorse.mclib.utils.ReflectionUtils;
 import mchorse.metamorph.api.morphs.AbstractMorph;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.Loader;
 
 public class ApertureTracker extends BaseTracker
 {
@@ -20,29 +22,32 @@ public class ApertureTracker extends BaseTracker
     {
         if(!ReflectionUtils.isOptifineShadowPass() && !this.name.equals(""))
         {
-            if (MinemaIntegration.isRecording() && this.trackingPacket == null)
+            if(CameraHandler.isApertureAndMinemaLoaded())
             {
-                CameraExporter.TrackingPacket packet = new CameraExporter.TrackingPacket(this.name, this.combineTracking);
-
-                if (GuiMinemaPanel.trackingExporter.addTracker(packet))
+                if (MinemaIntegration.isRecording() && this.trackingPacket == null)
                 {
-                    this.trackingPacket = packet;
+                    CameraExporter.TrackingPacket packet = new CameraExporter.TrackingPacket(this.name, this.combineTracking);
 
-                    //dont rename - when actors are present it can result in canMerge not being called before render
-                    //this.name = packet.getName();
+                    if (GuiMinemaPanel.trackingExporter.addTracker(packet))
+                    {
+                        this.trackingPacket = packet;
+
+                        //dont rename - when actors are present it can result in canMerge not being called before render
+                        //this.name = packet.getName();
+                    }
                 }
-            }
-            else if (!MinemaIntegration.isRecording() && this.trackingPacket != null)
-            {
-                if(this.trackingPacket.isReset())
+                else if (!MinemaIntegration.isRecording() && this.trackingPacket != null)
                 {
-                    this.trackingPacket = null;
+                    if(this.trackingPacket.isReset())
+                    {
+                        this.trackingPacket = null;
+                    }
                 }
-            }
 
-            if (MinemaIntegration.isRecording() && this.trackingPacket != null)
-            {
-                GuiMinemaPanel.trackingExporter.track(this.trackingPacket, target, partialTicks);
+                if (MinemaIntegration.isRecording() && this.trackingPacket != null)
+                {
+                    GuiMinemaPanel.trackingExporter.track(this.trackingPacket, target, partialTicks);
+                }
             }
         }
     }


### PR DESCRIPTION
- fixed crash because of ApertureTracker when aperture is not loaded
- added playback of audio on server when rejoining and syncing it
- added syncing mechanism for audio for servers (server-side option)
- added minema as optional dependency with version check